### PR TITLE
Add Statistics 101 course infrastructure

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 matplotlib==3.8.0
 numpy==1.26.4
 omegaconf==2.3.0
-pandas==2.0.3
+pandas==2.1.4
 Requests==2.31.0
 scikit_learn==1.4.1.post1
 torch==2.2.1

--- a/docs/source/Overviews/Statistics101.md
+++ b/docs/source/Overviews/Statistics101.md
@@ -1,0 +1,82 @@
+# Statistics 101
+
+
+## Chapters:
+
+### (1) Beginner
+
+#### (1.1) T-Test
+
+```
+Tag: available
+
+Author: 
+```
+
+#### (1.2) Chi-Square Test
+
+```
+Tag: available
+
+Author: 
+```
+
+#### (1.3) ANOVA
+
+```
+Tag: available
+
+Author: 
+```
+
+#### (1.4) Confidence Intervals & Hypothesis Testing
+
+```
+Tag: available
+
+Author: 
+```
+
+### (2) Moderate
+
+#### (2.1) Bootstrap Methods
+
+```
+Tag: available
+
+Author: 
+```
+
+#### (2.2) Missing Data & Imputation
+
+```
+Tag: available
+
+Author: 
+```
+
+### (3) Advanced
+
+#### (3.1) Mixed-Effects Models
+
+```
+Tag: available
+
+Author: 
+```
+
+#### (3.2) Item Response Theory (IRT)
+
+```
+Tag: available
+
+Author: 
+```
+
+#### (3.3) Non-parametric Methods
+
+```
+Tag: available
+
+Author: 
+```

--- a/docs/source/Overviews/overviews.md
+++ b/docs/source/Overviews/overviews.md
@@ -4,4 +4,5 @@
 :hidden:
 
 Datascience101
+Statistics101
 ```

--- a/docs/source/Statistics101/chapter_01_beginner/main.md
+++ b/docs/source/Statistics101/chapter_01_beginner/main.md
@@ -1,0 +1,8 @@
+# Chapter 01: Beginner Statistics
+
+## Lessons
+* T-Test
+* Chi-Square Test
+* ANOVA
+* Confidence Intervals & Hypothesis Testing
+* ...

--- a/docs/source/Statistics101/chapter_02_moderate/main.md
+++ b/docs/source/Statistics101/chapter_02_moderate/main.md
@@ -1,0 +1,6 @@
+# Chapter 02: Moderate Statistics
+
+## Lessons
+* Bootstrap Methods
+* Missing Data & Imputation
+* ...

--- a/docs/source/Statistics101/chapter_03_advanced/main.md
+++ b/docs/source/Statistics101/chapter_03_advanced/main.md
@@ -1,0 +1,7 @@
+# Chapter 03: Advanced Statistics
+
+## Lessons
+* Mixed-Effects Models
+* Item Response Theory (IRT)
+* Non-parametric Methods
+* ...

--- a/docs/source/Statistics101/main.md
+++ b/docs/source/Statistics101/main.md
@@ -1,0 +1,10 @@
+# Statistics 101
+
+```{toctree}
+:maxdepth: 2
+:caption: Chapters:
+chapter_01_beginner/main
+chapter_02_moderate/main
+chapter_03_advanced/main
+
+```

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -15,6 +15,7 @@ title: Welcome to AAI!
 
 Overviews/overviews
 Datascience101/main
+Statistics101/main
 ```
 
 <!-- ## Indices and tables


### PR DESCRIPTION
**This pull request makes the following changes**
* Adds page scaffolding for a new **Statistics 101** course with three chapters — Beginner (T-Test, Chi-Square, ANOVA, Confidence Intervals), Moderate (Bootstrap Methods, Missing Data & Imputation), and Advanced (Mixed-Effects Models, Item Response Theory, Non-parametric Methods)
* Wires the new course into the `Overviews` syllabus and the main site nav, mirroring the existing `Datascience101` layout
* No lesson content included — each topic is tagged `available` / no author in the [Overview](docs/source/Overviews/Statistics101.md) so it's ready to be picked up per the contribution flow in CONTRIBUTING.md
* Verified locally with `sphinx-build`: build succeeds, no warnings on the new pages

**Checklist**
* [x] I have read the [CONTRIBUTING](./CONTRIBUTING.md) document.
* [x] I have created a new branch from the current branch and made my changes over the new branch.
* [ ] There is an issue created for this pull request.
* [ ] I have linked the issue in the pull request description.

**Additional context**
No issue tracker entry for this yet — this was scoped directly. Follow-up PRs will add the actual lesson content for each topic.