### PR TITLE
Fix display-math rendering (blank-line-separate $$ blocks)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,22 @@
   environment above, and can break the build outright (pandas 2.0.3 had no
   Python 3.12 wheel; myst_nb was unpinned).
 
+- Display math must be a standalone block with **blank lines before and
+  after** the `$$` fences. A `$$ ... $$` equation crammed directly against a
+  prose line (no blank line between) is not parsed as display by MyST
+  dollarmath (`dmath_double_inline` is off) — the `$` pairing cascades and
+  renders the surrounding text as run-on italic math. Write:
+
+  ```
+  text before,
+
+  $$
+  equation
+  $$
+
+  more text.
+  ```
+
 - Hidden exercise solutions in lessons use native HTML `<details>` /
   `<summary>Solution</summary>` blocks with blank lines around the inner
   markdown (so MyST parses the math inside). No extra Sphinx extension needed.

--- a/docs/source/Datascience101/chapter_03_machine_learning_2/lessons/L01_fully_connected_neural_networks.md
+++ b/docs/source/Datascience101/chapter_03_machine_learning_2/lessons/L01_fully_connected_neural_networks.md
@@ -31,7 +31,6 @@ At this point it is less important to be familiar with the ins and outs of these
 
 More examples for activation functions and the characteristics of the ones listed can be found on [Wikipedia](https://en.wikipedia.org/wiki/Activation_function):
 
-
 ## Linear Layer
 
 Let's think about performing multiple logistic regressions in parallel, each with its own weight vector and bias, and then applying the activation function on each of these.
@@ -39,7 +38,6 @@ Let's think about performing multiple logistic regressions in parallel, each wit
 <img src="https://www.cs.rice.edu/~vo9/vislang/2017/notebooks/linear_layer.png" alt="deep_learning_lab" style="zoom:50%;" />
 
 Mathematically it can be written as: $a = g\left(W^Tx + b \right)$, whereas $W\in\mathbb{R}^{d\times l}, x\in\mathbb{R}^d, b\in\mathbb{R}^l, a\in Im(g)^l$, $l$ being the number of regression, and $g(\cdot)$​​ preformed per regression.
-
 
 ## Deep Fully Connected Neural Networks
 
@@ -53,11 +51,14 @@ There is a big importance for choosing a nonlinear activation function. By choos
 
 Mathematically: suppose a dual layer architecture with the parameters: $W_1\in\mathbb{R}^{d_1\times d_2}, b_1\in\mathbb{R}^{d_2}, W_2\in\mathbb{R}^{d_2\times d_3}, b_2\in\mathbb{R}^{d_3}$ and assume that for all layers, $g\left( W_l^Tx + b_l \right) = W_l^Tx + b_l$. 
 Hence, the output of the network is:
-$$W_2^T\left(W_1^Tx+b_1\right)+b_2=W_2^TW_1^Tx+W_2^Tb_1+b_2=\tilde{W}^Tx+\tilde{b},$$
+
+$$
+W_2^T\left(W_1^Tx+b_1\right)+b_2=W_2^TW_1^Tx+W_2^Tb_1+b_2=\tilde{W}^Tx+\tilde{b},
+$$
+
  which is practically equivalent for a single linear layer.
 
 ## Related Material
 
 [But what is a neural network? | Chapter 1, Deep learning - YouTube](https://www.youtube.com/watch?v=aircAruvnKk&ab_channel=3Blue1Brown)
-
 

--- a/docs/source/MLCrashCourse/chapter_01_trees_and_ensembles/lessons/L01_decision_trees.md
+++ b/docs/source/MLCrashCourse/chapter_01_trees_and_ensembles/lessons/L01_decision_trees.md
@@ -48,9 +48,11 @@ A fully grown tree has zero training error and huge variance: change a few sampl
 
 1. **Pre-pruning**: `max_depth`, `min_samples_leaf`, `min_impurity_decrease`.
 2. **Post-pruning** (CART's cost-complexity pruning): grow fully, then minimize
-   $$
+
+$$
    C_\alpha(T)=\sum_{m=1}^{|T|}n_m H(t_m)+\alpha|T|,
-   $$
+$$
+
    where $|T|$ is the number of leaves. Sweeping $\alpha$ produces a nested sequence of subtrees; pick $\alpha$ by cross-validation. This is $\ell_0$ regularization on the number of leaves — remember this form, XGBoost's objective (Lesson 05) contains exactly such a $\gamma|T|$ term.
 
 ## The Tree Family (the gist)

--- a/docs/source/MLCrashCourse/chapter_04_clustering/lessons/L01_kmeans_and_mixtures.md
+++ b/docs/source/MLCrashCourse/chapter_04_clustering/lessons/L01_kmeans_and_mixtures.md
@@ -49,15 +49,18 @@ $$
 Fitting by maximum likelihood has no closed form (the log of a sum), so we use **Expectation-Maximization**, which looks exactly like a soft Lloyd's algorithm:
 
 * **E-step** — soft assignment via Bayes' rule (the *responsibilities*):
-  $$
+
+$$
   \gamma_{ij}=\frac{\pi_j\,\mathcal{N}(x_i\mid\mu_j,\Sigma_j)}{\sum_{l}\pi_l\,\mathcal{N}(x_i\mid\mu_l,\Sigma_l)} .
-  $$
+$$
+
 * **M-step** — weighted maximum-likelihood updates:
-  $$
+
+$$
   \mu_j=\frac{\sum_i\gamma_{ij}x_i}{\sum_i\gamma_{ij}},\qquad
   \Sigma_j=\frac{\sum_i\gamma_{ij}(x_i-\mu_j)(x_i-\mu_j)^T}{\sum_i\gamma_{ij}},\qquad
   \pi_j=\frac{1}{n}\sum_i\gamma_{ij} .
-  $$
+$$
 
 Each iteration provably increases the likelihood (EM maximizes a lower bound that is tight at the current parameters). In the limit of shared covariances $\Sigma_j=\sigma^2 I$ with $\sigma\to0$, the responsibilities harden to nearest-center assignment and EM *becomes* k-means — which tells you precisely which assumptions k-means silently makes.
 

--- a/docs/source/Statistics301/chapter_03_advanced_modeling/lessons/L01_mixed_effects_models.md
+++ b/docs/source/Statistics301/chapter_03_advanced_modeling/lessons/L01_mixed_effects_models.md
@@ -15,13 +15,25 @@ A factor's levels are treated as **fixed** when they are the specific levels of 
 ### Random intercept/slope model in matrix form
 
 For cluster $i = 1, \dots, m$ with $n_i$ observations, the linear mixed model is
-$$ y_i = X_i \beta + Z_i b_i + \epsilon_i, \qquad b_i \sim N(0, D), \qquad \epsilon_i \sim N(0, \sigma^2 I_{n_i}), $$
+
+$$
+y_i = X_i \beta + Z_i b_i + \epsilon_i, \qquad b_i \sim N(0, D), \qquad \epsilon_i \sim N(0, \sigma^2 I_{n_i}),
+$$
+
 with $b_1, \dots, b_m$ mutually independent, independent across clusters of $\epsilon_i$, and $b_i \perp \epsilon_i$. Here $X_i$ is the $n_i \times p$ fixed-effects design matrix and $Z_i$ is the $n_i \times q$ random-effects design matrix.
 
 For a **random intercept and slope** model with a single time covariate $t_{ij}$, $Z_i$ has columns $(1, t_{ij})$ and $b_i = (b_{0i}, b_{1i})^T \sim N(0, D)$ with
-$$ D = \begin{pmatrix} \sigma_0^2 & \sigma_{01} \\ \sigma_{01} & \sigma_1^2 \end{pmatrix}. $$
+
+$$
+D = \begin{pmatrix} \sigma_0^2 & \sigma_{01} \\ \sigma_{01} & \sigma_1^2 \end{pmatrix}.
+$$
+
 Marginalizing over $b_i$ gives $y_i \sim N(X_i\beta, V_i)$ with
-$$ V_i = Z_i D Z_i^T + \sigma^2 I_{n_i}. $$
+
+$$
+V_i = Z_i D Z_i^T + \sigma^2 I_{n_i}.
+$$
+
 Stacking clusters, $y = X\beta + Zb + \epsilon$ with $b \sim N(0, G)$, $G = I_m \otimes D$ block-diagonal, and marginal covariance $V = ZGZ^T + R$, $R = \sigma^2 I$.
 
 ### Nested vs. crossed effects
@@ -33,19 +45,35 @@ Random effects are **nested** when each level of one factor occurs within exactl
 ### ML vs. REML
 
 Given variance components $\theta$ (the free parameters of $D$ and $\sigma^2$), maximum likelihood maximizes
-$$ L(\beta, \theta) = \prod_{i=1}^m \phi\big(y_i; X_i\beta, V_i(\theta)\big) $$
+
+$$
+L(\beta, \theta) = \prod_{i=1}^m \phi\big(y_i; X_i\beta, V_i(\theta)\big)
+$$
+
 jointly over $\beta$ and $\theta$. As in ordinary regression, where the MLE of $\sigma^2$ divides by $n$ rather than $n-p$, the ML estimator of the variance components is downward biased because it does not account for the degrees of freedom used to estimate $\beta$.
 
 **REML** (restricted/residual maximum likelihood) corrects this by maximizing the likelihood of error contrasts, linear combinations $K^Ty$ with $K^TX = 0$, that do not depend on $\beta$ at all:
-$$ L_{REML}(\theta) \propto |V(\theta)|^{-1/2}\, |X^TV(\theta)^{-1}X|^{-1/2} \exp\!\left(-\tfrac12 (y-X\hat\beta(\theta))^T V(\theta)^{-1} (y-X\hat\beta(\theta))\right). $$
+
+$$
+L_{REML}(\theta) \propto |V(\theta)|^{-1/2}\, |X^TV(\theta)^{-1}X|^{-1/2} \exp\!\left(-\tfrac12 (y-X\hat\beta(\theta))^T V(\theta)^{-1} (y-X\hat\beta(\theta))\right).
+$$
+
 REML variance-component estimates are unbiased in balanced designs and are the default for reporting variance components. However, because $L_{REML}$ depends on $X$ through the projection removing $\beta$, REML likelihoods are **not comparable across models with different fixed effects**; when comparing nested fixed-effects specifications by likelihood-ratio test, one must refit with ML.
 
 ### BLUP and shrinkage
 
 For known $\theta$, the generalized least squares estimator is $\hat\beta = (X^TV^{-1}X)^{-1}X^TV^{-1}y$. The best linear unbiased predictor of the random effect is
-$$ \hat b_i = D Z_i^T V_i^{-1}(y_i - X_i\hat\beta). $$
+
+$$
+\hat b_i = D Z_i^T V_i^{-1}(y_i - X_i\hat\beta).
+$$
+
 This is a **shrinkage** estimator: it pulls the cluster's raw deviation toward zero (the population value), with the amount of shrinkage governed by cluster size and the ratio of between- to within-cluster variance. In the random-intercept-only case,
-$$ \hat b_{0i} = \lambda_i (\bar y_i - x_i^T\hat\beta), \qquad \lambda_i = \frac{n_i \sigma_0^2}{n_i\sigma_0^2 + \sigma^2} \in (0,1). $$
+
+$$
+\hat b_{0i} = \lambda_i (\bar y_i - x_i^T\hat\beta), \qquad \lambda_i = \frac{n_i \sigma_0^2}{n_i\sigma_0^2 + \sigma^2} \in (0,1).
+$$
+
 Small or noisy clusters (small $n_i$, or small $\sigma_0^2$ relative to $\sigma^2$) are shrunk more heavily toward the population mean; this is exactly the same shrinkage logic as in empirical Bayes estimation.
 
 ## Inference on Variance Components
@@ -53,13 +81,21 @@ Small or noisy clusters (small $n_i$, or small $\sigma_0^2$ relative to $\sigma^
 ### Likelihood-ratio testing for variance components (the boundary issue)
 
 Testing $H_0: \sigma_0^2 = 0$ (no random intercept needed) is nonstandard: $0$ is on the **boundary** of the parameter space for a variance, so the usual regularity conditions for $-2\log\Lambda \to \chi^2_1$ under $H_0$ fail. Self and Liang (1987) showed that when testing a single variance component at the boundary, the asymptotic null distribution of the LRT statistic is a 50:50 mixture of a point mass at 0 and a $\chi^2_1$:
-$$ -2\log\Lambda \;\xrightarrow{d}\; \tfrac12 \chi^2_0 + \tfrac12 \chi^2_1 \quad \text{(written } \bar\chi^2_{01}\text{)}. $$
+
+$$
+-2\log\Lambda \;\xrightarrow{d}\; \tfrac12 \chi^2_0 + \tfrac12 \chi^2_1 \quad \text{(written } \bar\chi^2_{01}\text{)}.
+$$
+
 Practically, this means the naive p-value obtained by comparing the LRT statistic to a $\chi^2_1$ reference is roughly **twice too large** (conservative); the corrected p-value is approximately half the naive one. When testing $q \geq 2$ variance components jointly (e.g., a random slope's variance together with its covariance with the intercept), the reference distribution is a mixture of $\chi^2_{q-1}$ and $\chi^2_q$ with mixing weights that generally must be simulated or looked up.
 
 ### ICC
 
 For the random-intercept model, the **intraclass correlation coefficient** is
-$$ \rho = \frac{\sigma_0^2}{\sigma_0^2 + \sigma^2}. $$
+
+$$
+\rho = \frac{\sigma_0^2}{\sigma_0^2 + \sigma^2}.
+$$
+
 It equals both the proportion of total variance attributable to between-cluster differences, and the model-implied correlation between two observations $y_{ij}, y_{ik}$ ($j \ne k$) drawn from the same cluster $i$, since $Cov(y_{ij}, y_{ik}) = \sigma_0^2$ and $Var(y_{ij}) = \sigma_0^2+\sigma^2$ under the compound-symmetric marginal covariance implied by a single random intercept.
 
 ## Worked Example
@@ -75,17 +111,36 @@ Four schools (clusters), three students each, test scores:
 
 Grand mean $\bar y = 6.75$. This is a balanced one-way random-effects design, so the ANOVA-based variance component estimators coincide with REML.
 
-$$ SSB = n\sum_i (\bar y_i - \bar y)^2 = 3\big[0.5625+5.0625+7.5625+1.5625\big] = 44.25, \quad MSB = 44.25/3 = 14.75 $$
-$$ SSW = \sum_i\sum_j (y_{ij}-\bar y_i)^2 = 2+2+2+2 = 8, \quad MSW = 8/8 = 1 $$
+$$
+SSB = n\sum_i (\bar y_i - \bar y)^2 = 3\big[0.5625+5.0625+7.5625+1.5625\big] = 44.25, \quad MSB = 44.25/3 = 14.75
+$$
+
+$$
+SSW = \sum_i\sum_j (y_{ij}-\bar y_i)^2 = 2+2+2+2 = 8, \quad MSW = 8/8 = 1
+$$
 
 So $\hat\sigma^2 = MSW = 1$ and, using $n=3$ observations per group,
-$$ \hat\sigma_0^2 = \frac{MSB - MSW}{n} = \frac{14.75-1}{3} = 4.5833. $$
-$$ \widehat{ICC} = \frac{4.5833}{4.5833+1} = 0.821. $$
+
+$$
+\hat\sigma_0^2 = \frac{MSB - MSW}{n} = \frac{14.75-1}{3} = 4.5833.
+$$
+
+$$
+\widehat{ICC} = \frac{4.5833}{4.5833+1} = 0.821.
+$$
+
 Over 82% of the variance in scores is between-school; schools differ substantially.
 
 **BLUP for group 3** (raw mean 4.00, furthest below the grand mean): shrinkage factor
-$$ \lambda_3 = \frac{3(4.5833)}{3(4.5833)+1} = \frac{13.75}{14.75} = 0.932, $$
-$$ \hat b_{0,3} = \lambda_3(\bar y_3 - \hat\beta) = 0.932 \times (4.00 - 6.75) = -2.564. $$
+
+$$
+\lambda_3 = \frac{3(4.5833)}{3(4.5833)+1} = \frac{13.75}{14.75} = 0.932,
+$$
+
+$$
+\hat b_{0,3} = \lambda_3(\bar y_3 - \hat\beta) = 0.932 \times (4.00 - 6.75) = -2.564.
+$$
+
 The predicted school-3 intercept is $6.75 - 2.564 = 4.186$, shrunk slightly toward the grand mean rather than sitting at the raw 4.00, because with only $n_i=3$ and $\sigma^2$ non-negligible relative to $\sigma_0^2$, some of the observed deviation is attributed to noise.
 
 ```python
@@ -104,11 +159,19 @@ Derive the marginal covariance matrix $V_i = Z_iDZ_i^T + \sigma^2 I_{n_i}$ for a
 <summary>Solution</summary>
 
 With $Z_i = \mathbf{1}_{n_i}$ (an $n_i \times 1$ column of ones) and $D = \sigma_0^2$ (a scalar), $Z_iDZ_i^T = \sigma_0^2 \mathbf{1}_{n_i}\mathbf{1}_{n_i}^T = \sigma_0^2 J_{n_i}$, where $J_{n_i}$ is the $n_i\times n_i$ matrix of all ones. Hence
-$$ V_i = \sigma_0^2 J_{n_i} + \sigma^2 I_{n_i}. $$
+
+$$
+V_i = \sigma_0^2 J_{n_i} + \sigma^2 I_{n_i}.
+$$
+
 Element-wise, the diagonal entries are $\sigma_0^2 + \sigma^2$ (since $J_{ii}=1$ and $I_{ii}=1$) and the off-diagonal entries are $\sigma_0^2$ (since $J_{ij}=1, I_{ij}=0$ for $i\ne j$). This is exactly the compound-symmetric structure: constant variance, constant covariance.
 
 The correlation between $y_{ij}$ and $y_{ik}$, $j\ne k$, in the same cluster is
-$$ Corr(y_{ij},y_{ik}) = \frac{Cov(y_{ij},y_{ik})}{\sqrt{Var(y_{ij})Var(y_{ik})}} = \frac{\sigma_0^2}{\sigma_0^2+\sigma^2}, $$
+
+$$
+Corr(y_{ij},y_{ik}) = \frac{Cov(y_{ij},y_{ik})}{\sqrt{Var(y_{ij})Var(y_{ik})}} = \frac{\sigma_0^2}{\sigma_0^2+\sigma^2},
+$$
+
 since both variances equal $\sigma_0^2+\sigma^2$. This matches $\rho = \sigma_0^2/(\sigma_0^2+\sigma^2)$, confirming the ICC is precisely the within-cluster correlation implied by the random-intercept model, not merely a variance-decomposition heuristic.
 
 </details>
@@ -121,16 +184,31 @@ Derive the BLUP $\hat b_i = DZ_i^TV_i^{-1}(y_i - X_i\beta)$ from the joint norma
 <summary>Solution</summary>
 
 Under the model, $(y_i, b_i)$ is jointly Gaussian with
-$$ \begin{pmatrix} y_i \\ b_i \end{pmatrix} \sim N\left( \begin{pmatrix} X_i\beta \\ 0 \end{pmatrix}, \begin{pmatrix} V_i & Z_iD \\ DZ_i^T & D \end{pmatrix} \right), $$
+
+$$
+\begin{pmatrix} y_i \\ b_i \end{pmatrix} \sim N\left( \begin{pmatrix} X_i\beta \\ 0 \end{pmatrix}, \begin{pmatrix} V_i & Z_iD \\ DZ_i^T & D \end{pmatrix} \right),
+$$
+
 because $Cov(y_i, b_i) = Cov(X_i\beta + Z_ib_i+\epsilon_i, b_i) = Z_i Cov(b_i,b_i) = Z_iD$, and $Var(b_i)=D$.
 
 For a jointly Gaussian vector $(U,W)$ with $U\sim N(\mu_U,\Sigma_{UU})$, $W \sim N(\mu_W,\Sigma_{WW})$, and cross-covariance $\Sigma_{WU}$, the conditional expectation is
-$$ E[W\mid U] = \mu_W + \Sigma_{WU}\Sigma_{UU}^{-1}(U-\mu_U). $$
+
+$$
+E[W\mid U] = \mu_W + \Sigma_{WU}\Sigma_{UU}^{-1}(U-\mu_U).
+$$
+
 Applying this with $W = b_i$ ($\mu_W=0$), $U = y_i$ ($\mu_U = X_i\beta$), $\Sigma_{WU} = DZ_i^T$, $\Sigma_{UU}=V_i$:
-$$ E[b_i \mid y_i] = DZ_i^T V_i^{-1}(y_i - X_i\beta) = \hat b_i. $$
+
+$$
+E[b_i \mid y_i] = DZ_i^T V_i^{-1}(y_i - X_i\beta) = \hat b_i.
+$$
 
 Optimality among linear unbiased predictors: any linear predictor $\tilde b_i = A y_i$ is unbiased for $b_i$ (in the sense $E[\tilde b_i - b_i]=0$ over the joint distribution) if $AX_i = 0$. Its MSE is $E\|Ay_i - b_i\|^2$. Writing $Ay_i - b_i = A(X_i\beta+Z_ib_i+\epsilon_i) - b_i = A\epsilon_i + (AZ_i-I)b_i$ (using $AX_i\beta=0$), and using independence of $\epsilon_i,b_i$,
-$$ MSE(A) = \sigma^2 AA^T + (AZ_i-I)D(AZ_i-I)^T. $$
+
+$$
+MSE(A) = \sigma^2 AA^T + (AZ_i-I)D(AZ_i-I)^T.
+$$
+
 Minimizing the trace of this quadratic form over $A$ subject to $AX_i=0$ is a constrained least-squares problem; setting the (constrained) gradient to zero yields exactly $A = DZ_i^TV_i^{-1}$ up to the projection removing the $X_i\beta$ component, reproducing $\hat b_i$. Since the conditional-expectation solution already satisfies $AX_i=0$ (because $Cov(b_i, X_i\beta)=0$ makes the predictor automatically orthogonal to the fixed part), the two derivations agree: the BLUP is simultaneously the conditional mean under normality and the minimum-MSE linear unbiased predictor, which is why it generalizes (as the "best linear unbiased predictor") to non-Gaussian settings via the Gauss-Markov-type argument alone.
 
 </details>
@@ -145,17 +223,35 @@ For the balanced one-way random-effects model $y_{ij} = \mu + b_i + \epsilon_{ij
 Write $y_{ij} = \mu + b_i + \epsilon_{ij}$. Group mean $\bar y_i = \mu + b_i + \bar\epsilon_i$, grand mean $\bar y = \mu + \bar b + \bar{\bar\epsilon}$ where $\bar b = m^{-1}\sum_i b_i$, $\bar\epsilon_i = n^{-1}\sum_j \epsilon_{ij}$.
 
 **Within groups:** $y_{ij}-\bar y_i = \epsilon_{ij}-\bar\epsilon_i$, which does not involve $b_i$ at all. So $SSW = \sum_i\sum_j(\epsilon_{ij}-\bar\epsilon_i)^2$ is exactly the usual within-group sum of squares of iid $N(0,\sigma^2)$ errors, with $m(n-1)$ degrees of freedom. Standard result (same as one-way fixed-effects ANOVA from Stats 2): $E[SSW] = m(n-1)\sigma^2$, so
-$$ E[MSW] = E[SSW/(m(n-1))] = \sigma^2. $$
+
+$$
+E[MSW] = E[SSW/(m(n-1))] = \sigma^2.
+$$
 
 **Between groups:** $\bar y_i - \bar y = (b_i - \bar b) + (\bar\epsilon_i - \bar{\bar\epsilon})$. Then
-$$ SSB = n\sum_i(\bar y_i-\bar y)^2 = n\sum_i\big[(b_i-\bar b)+(\bar\epsilon_i-\bar{\bar\epsilon})\big]^2. $$
+
+$$
+SSB = n\sum_i(\bar y_i-\bar y)^2 = n\sum_i\big[(b_i-\bar b)+(\bar\epsilon_i-\bar{\bar\epsilon})\big]^2.
+$$
+
 Expand the square; cross terms vanish in expectation since $b_i \perp \epsilon$. So
-$$ E[SSB] = n\, E\Big[\sum_i (b_i-\bar b)^2\Big] + n\, E\Big[\sum_i(\bar\epsilon_i - \bar{\bar\epsilon})^2\Big]. $$
+
+$$
+E[SSB] = n\, E\Big[\sum_i (b_i-\bar b)^2\Big] + n\, E\Big[\sum_i(\bar\epsilon_i - \bar{\bar\epsilon})^2\Big].
+$$
+
 For the first term, $b_1,\dots,b_m$ are iid $N(0,\sigma_0^2)$, so $\sum_i(b_i-\bar b)^2$ has expectation $(m-1)\sigma_0^2$ (standard unbiased-sample-variance identity). For the second term, $\bar\epsilon_i$ are iid $N(0,\sigma^2/n)$, so $\sum_i(\bar\epsilon_i-\bar{\bar\epsilon})^2$ has expectation $(m-1)\sigma^2/n$. Hence
-$$ E[SSB] = n(m-1)\sigma_0^2 + (m-1)\sigma^2, \qquad E[MSB] = E[SSB/(m-1)] = n\sigma_0^2+\sigma^2. $$
+
+$$
+E[SSB] = n(m-1)\sigma_0^2 + (m-1)\sigma^2, \qquad E[MSB] = E[SSB/(m-1)] = n\sigma_0^2+\sigma^2.
+$$
 
 **Unbiasedness of the moment estimators:**
-$$ E[\hat\sigma^2] = E[MSW] = \sigma^2, \qquad E[\hat\sigma_0^2] = \frac{E[MSB]-E[MSW]}{n} = \frac{(n\sigma_0^2+\sigma^2)-\sigma^2}{n} = \sigma_0^2. $$
+
+$$
+E[\hat\sigma^2] = E[MSW] = \sigma^2, \qquad E[\hat\sigma_0^2] = \frac{E[MSB]-E[MSW]}{n} = \frac{(n\sigma_0^2+\sigma^2)-\sigma^2}{n} = \sigma_0^2.
+$$
+
 Both are unbiased. This ANOVA-based construction coincides with the REML estimators in the balanced case, which is why REML (not ML) is the natural generalization of the "$n-p$ correction" intuition from Stats 1/2 to variance components.
 
 </details>
@@ -168,10 +264,16 @@ In a study, you fit a random-intercept model and a fixed-effects-only model by R
 <summary>Solution</summary>
 
 (a) Naive approach: treat $-2\log\Lambda = 3.5$ as $\chi^2_1$. We need $P(\chi^2_1 > 3.5)$. Since $\chi^2_1 = Z^2$ for $Z\sim N(0,1)$, $P(\chi^2_1>3.5) = P(|Z|>\sqrt{3.5}) = P(|Z|>1.8708) = 2(1-\Phi(1.8708))$. From the standard normal table, $\Phi(1.8708)\approx 0.9693$, so
-$$ p_{naive} = 2(1-0.9693) = 2(0.0307) = 0.0614. $$
+
+$$
+p_{naive} = 2(1-0.9693) = 2(0.0307) = 0.0614.
+$$
 
 (b) Under the correct mixture $\tfrac12\chi^2_0 + \tfrac12\chi^2_1$, the point mass $\chi^2_0$ contributes zero probability to the event $\{T>3.5\}$ for any $3.5>0$, so
-$$ p_{corrected} = P(\bar\chi^2_{01} > 3.5) = \tfrac12 P(\chi^2_0>3.5) + \tfrac12 P(\chi^2_1>3.5) = 0 + \tfrac12(0.0614) = 0.0307. $$
+
+$$
+p_{corrected} = P(\bar\chi^2_{01} > 3.5) = \tfrac12 P(\chi^2_0>3.5) + \tfrac12 P(\chi^2_1>3.5) = 0 + \tfrac12(0.0614) = 0.0307.
+$$
 
 The corrected p-value is exactly half the naive one, as the general theory predicts: comparing the boundary LRT statistic to an ordinary $\chi^2_1$ reference is conservative (the naive p-value overstates the true p-value by a factor of 2), because half of the null sampling distribution's mass sits at exactly 0 (whenever the unconstrained REML/ML optimizer would want $\hat\sigma_0^2<0$, it is truncated to $0$, making $-2\log\Lambda=0$ on those samples) rather than following $\chi^2_1$ throughout. Using the naive $\chi^2_1$ p-value as a decision rule at $\alpha=0.05$ would fail to reject in this example ($0.0614>0.05$), while the corrected mixture test does reject ($0.0307<0.05$), so the boundary correction can change the conclusion of the test.
 

--- a/docs/source/Statistics301/chapter_03_advanced_modeling/lessons/L02_item_response_theory.md
+++ b/docs/source/Statistics301/chapter_03_advanced_modeling/lessons/L02_item_response_theory.md
@@ -9,32 +9,57 @@ Classical test theory summarizes a test-taker's performance by a raw or percent-
 ### The latent trait framework
 
 Let $\theta_j$ denote the latent ability of person $j$, and let $X_{ij} \in \{0,1\}$ be the response of person $j$ to item $i$ (correct/incorrect). The central modeling assumption is **local independence**: conditional on $\theta_j$, the responses to different items are independent,
-$$ P(X_{1j}=x_1,\dots,X_{Kj}=x_K \mid \theta_j) = \prod_{i=1}^K P(X_{ij}=x_i\mid\theta_j). $$
+
+$$
+P(X_{1j}=x_1,\dots,X_{Kj}=x_K \mid \theta_j) = \prod_{i=1}^K P(X_{ij}=x_i\mid\theta_j).
+$$
+
 The function $P_i(\theta) = P(X_i=1\mid\theta)$ is the **item characteristic curve** (ICC): a monotonically increasing, S-shaped function of ability.
 
 ### Rasch (1PL) model
 
-$$ P_i(\theta) = P(X_{ij}=1\mid\theta_j,b_i) = \frac{\exp(\theta_j-b_i)}{1+\exp(\theta_j-b_i)}, $$
+$$
+P_i(\theta) = P(X_{ij}=1\mid\theta_j,b_i) = \frac{\exp(\theta_j-b_i)}{1+\exp(\theta_j-b_i)},
+$$
+
 where $b_i$ is the item's **difficulty** (the ability level at which $P_i=0.5$). The Rasch model has a distinguishing mathematical property: the total raw score $\sum_i X_{ij}$ is a **sufficient statistic** for $\theta_j$ (proved in Exercise 2), and person and item parameters are "separable" in the sense that conditional maximum likelihood can estimate item parameters without knowing any $\theta_j$.
 
 ### 2PL model
 
-$$ P_i(\theta) = \frac{\exp\big(a_i(\theta-b_i)\big)}{1+\exp\big(a_i(\theta-b_i)\big)}, $$
+$$
+P_i(\theta) = \frac{\exp\big(a_i(\theta-b_i)\big)}{1+\exp\big(a_i(\theta-b_i)\big)},
+$$
+
 adding a **discrimination** parameter $a_i>0$ controlling the steepness of the ICC at $\theta=b_i$. Larger $a_i$ means the item more sharply distinguishes examinees just below vs. just above $b_i$; raw score is no longer sufficient for $\theta$ once items differ in $a_i$.
 
 ### 3PL model
 
-$$ P_i(\theta) = c_i + (1-c_i)\,\frac{\exp\big(a_i(\theta-b_i)\big)}{1+\exp\big(a_i(\theta-b_i)\big)}, $$
+$$
+P_i(\theta) = c_i + (1-c_i)\,\frac{\exp\big(a_i(\theta-b_i)\big)}{1+\exp\big(a_i(\theta-b_i)\big)},
+$$
+
 adding a **guessing** (pseudo-guessing) parameter $c_i\in[0,1)$, a lower asymptote representing the chance of a correct response from an examinee with vanishingly low ability (relevant for multiple-choice items). The ICC now ranges from $c_i$ to $1$ rather than from $0$ to $1$.
 
 ## Item and Test Information
 
 Fisher information quantifies how precisely an item (or test) can pin down $\theta$. For the 2PL model,
-$$ I_i(\theta) = a_i^2\, P_i(\theta)\big(1-P_i(\theta)\big), $$
+
+$$
+I_i(\theta) = a_i^2\, P_i(\theta)\big(1-P_i(\theta)\big),
+$$
+
 maximized at $\theta = b_i$ where $P_i=0.5$, and increasing in $a_i^2$: highly discriminating items concentrated near a test-taker's ability level are maximally informative. For the 3PL model, the lower asymptote attenuates information:
-$$ I_i(\theta) = a_i^2\,\frac{\big(P_i(\theta)-c_i\big)^2}{(1-c_i)^2}\cdot\frac{1-P_i(\theta)}{P_i(\theta)}. $$
+
+$$
+I_i(\theta) = a_i^2\,\frac{\big(P_i(\theta)-c_i\big)^2}{(1-c_i)^2}\cdot\frac{1-P_i(\theta)}{P_i(\theta)}.
+$$
+
 Because local independence makes the log-likelihood additive across items, Fisher information is additive too:
-$$ I(\theta) = \sum_{i=1}^K I_i(\theta), \qquad SE(\hat\theta) \approx \frac{1}{\sqrt{I(\theta)}}. $$
+
+$$
+I(\theta) = \sum_{i=1}^K I_i(\theta), \qquad SE(\hat\theta) \approx \frac{1}{\sqrt{I(\theta)}}.
+$$
+
 This is the basis of computerized adaptive testing: at each step, administer the item that maximizes information at the current ability estimate.
 
 ## Estimation: Marginal ML and Ability Estimation
@@ -42,7 +67,11 @@ This is the basis of computerized adaptive testing: at each step, administer the
 ### Marginal maximum likelihood (integrating out ability)
 
 When calibrating item parameters $\xi = \{a_i,b_i,c_i\}$ from a sample of $N$ examinees, treating each $\theta_j$ as a fixed unknown ("joint MLE") produces inconsistent item-parameter estimates as $N\to\infty$ with a fixed test length (the incidental-parameters problem: the number of $\theta_j$'s grows with $N$). The standard remedy is **marginal maximum likelihood** (MMLE): treat $\theta_j$ as random with a population distribution $g(\theta)$ (typically $N(0,1)$) and integrate it out,
-$$ L(\xi) = \prod_{j=1}^N \int \prod_{i=1}^K P_i(\theta)^{x_{ij}}\big(1-P_i(\theta)\big)^{1-x_{ij}}\, g(\theta)\,d\theta. $$
+
+$$
+L(\xi) = \prod_{j=1}^N \int \prod_{i=1}^K P_i(\theta)^{x_{ij}}\big(1-P_i(\theta)\big)^{1-x_{ij}}\, g(\theta)\,d\theta.
+$$
+
 This marginal likelihood is maximized via the EM algorithm (Bock and Aitkin, 1981): the E-step approximates the integral by Gauss-Hermite quadrature and computes, for each quadrature node, the posterior-weighted expected number of examinees and correct responses; the M-step then updates $\{a_i,b_i,c_i\}$ item-by-item via weighted logistic regression on the pseudo-data from the E-step. This mirrors exactly the structure of estimating a generalized linear mixed model by integrating out a random intercept, which is the conceptual link developed below.
 
 ### Ability estimation: MLE and EAP
@@ -50,11 +79,19 @@ This marginal likelihood is maximized via the EM algorithm (Bock and Aitkin, 198
 Once item parameters are calibrated (treated as known), a person's ability is estimated from their response pattern.
 
 **MLE**: maximize $\ell(\theta) = \sum_i \big[x_i\log P_i(\theta) + (1-x_i)\log(1-P_i(\theta))\big]$ via Newton-Raphson,
-$$ \theta^{(t+1)} = \theta^{(t)} + \frac{\sum_i (x_i - P_i(\theta^{(t)}))}{\sum_i P_i(\theta^{(t)})(1-P_i(\theta^{(t)}))} \quad \text{(Rasch case, } a_i=1\text{)}. $$
+
+$$
+\theta^{(t+1)} = \theta^{(t)} + \frac{\sum_i (x_i - P_i(\theta^{(t)}))}{\sum_i P_i(\theta^{(t)})(1-P_i(\theta^{(t)}))} \quad \text{(Rasch case, } a_i=1\text{)}.
+$$
+
 MLE is undefined (diverges to $\pm\infty$) for all-correct or all-incorrect response patterns, since the likelihood is then monotonic in $\theta$ with no interior maximum.
 
 **EAP** (expected a posteriori, Bayesian) avoids this by using a prior $g(\theta)$:
-$$ \hat\theta_{EAP} = E[\theta\mid x] = \frac{\int \theta\, L(x\mid\theta)\, g(\theta)\, d\theta}{\int L(x\mid\theta)\, g(\theta)\, d\theta}, $$
+
+$$
+\hat\theta_{EAP} = E[\theta\mid x] = \frac{\int \theta\, L(x\mid\theta)\, g(\theta)\, d\theta}{\int L(x\mid\theta)\, g(\theta)\, d\theta},
+$$
+
 computed by quadrature. Like the BLUP of Lesson 1, EAP shrinks extreme response patterns toward the prior mean and is always finite, at the cost of some bias toward the prior for examinees with genuinely extreme ability.
 
 ## DIF and the Link to Logistic Mixed Models
@@ -70,22 +107,41 @@ An item shows **DIF** if examinees from different groups (e.g., defined by langu
 ### Link to logistic mixed models
 
 Rewrite the Rasch model with person ability treated as random rather than fixed:
-$$ \text{logit}\, P(X_{ij}=1) = \theta_j - b_i, \qquad \theta_j \sim N(0,\sigma^2), $$
+
+$$
+\text{logit}\, P(X_{ij}=1) = \theta_j - b_i, \qquad \theta_j \sim N(0,\sigma^2),
+$$
+
 with items as fixed effects (a factor with $K-1$ contrasts) and persons as a random intercept. This is *exactly* a logistic mixed model (a generalized linear mixed model with binomial response and random intercept per person), fittable with standard mixed-model software using a person random effect and an item fixed effect, e.g. `glmer(correct ~ item + (1|person), family=binomial)`. Marginal ML for the Rasch model, integrating over the person random effect, coincides with GLMM estimation via Gauss-Hermite quadrature. The 2PL model, by contrast, has $a_i\theta_j$, a *product* of an item parameter and the random effect, which behaves like a person-specific "random slope on a latent factor" and is not a standard GLMM; it requires either specialized IRT software or a nonlinear mixed-model formulation. This connection is why many applied papers describe the Rasch model as "a logistic mixed model with items as fixed effects and persons as random effects."
 
 ## Worked Example
 
 Three items with Rasch difficulties $b = (-1, 0, 1)$; examinee with $\theta = 0.5$.
 
-$$ P_1 = \frac{e^{0.5-(-1)}}{1+e^{1.5}} = \frac{e^{1.5}}{1+e^{1.5}} = \frac{4.4817}{5.4817} = 0.8176 $$
-$$ P_2 = \frac{e^{0.5}}{1+e^{0.5}} = \frac{1.6487}{2.6487} = 0.6225, \qquad P_3 = \frac{e^{-0.5}}{1+e^{-0.5}} = \frac{0.6065}{1.6065} = 0.3775 $$
+$$
+P_1 = \frac{e^{0.5-(-1)}}{1+e^{1.5}} = \frac{e^{1.5}}{1+e^{1.5}} = \frac{4.4817}{5.4817} = 0.8176
+$$
+
+$$
+P_2 = \frac{e^{0.5}}{1+e^{0.5}} = \frac{1.6487}{2.6487} = 0.6225, \qquad P_3 = \frac{e^{-0.5}}{1+e^{-0.5}} = \frac{0.6065}{1.6065} = 0.3775
+$$
 
 Item informations ($I_i = P_i(1-P_i)$ since $a_i=1$): $I_1 = 0.8176\times0.1824 = 0.1491$, $I_2 = 0.6225\times0.3775 = 0.2350$, $I_3 = 0.3775\times0.6225=0.2350$. Test information $I(0.5) = 0.6191$, so $SE(\hat\theta) = 1/\sqrt{0.6191} = 1.2708$.
 
 Suppose the examinee's observed pattern is $x=(1,1,0)$ (correct on items 1-2, incorrect on 3). One Newton-Raphson step from $\theta^{(0)}=0.5$:
-$$ \text{score} = (1-0.8176)+(1-0.6225)+(0-0.3775) = 0.1824+0.3775-0.3775 = 0.1824 $$
-$$ \text{information} = I_1+I_2+I_3 = 0.6191 $$
-$$ \theta^{(1)} = 0.5 + \frac{0.1824}{0.6191} = 0.5+0.2947 = 0.7947. $$
+
+$$
+\text{score} = (1-0.8176)+(1-0.6225)+(0-0.3775) = 0.1824+0.3775-0.3775 = 0.1824
+$$
+
+$$
+\text{information} = I_1+I_2+I_3 = 0.6191
+$$
+
+$$
+\theta^{(1)} = 0.5 + \frac{0.1824}{0.6191} = 0.5+0.2947 = 0.7947.
+$$
+
 This is identical in form to a Fisher-scoring step for logistic regression MLE, since the Rasch score/information equations are exactly the logistic-regression score/information equations with the $b_i$ acting as known offsets.
 
 ## Exercises
@@ -98,15 +154,27 @@ Derive the score function and Fisher information for MLE ability estimation in t
 <summary>Solution</summary>
 
 The log-likelihood for a single examinee's pattern $x=(x_1,\dots,x_K)$ given ability $\theta$ is
-$$ \ell(\theta) = \sum_{i=1}^K \Big[x_i\log P_i(\theta) + (1-x_i)\log(1-P_i(\theta))\Big], \qquad P_i(\theta) = \frac{e^{\theta-b_i}}{1+e^{\theta-b_i}}. $$
+
+$$
+\ell(\theta) = \sum_{i=1}^K \Big[x_i\log P_i(\theta) + (1-x_i)\log(1-P_i(\theta))\Big], \qquad P_i(\theta) = \frac{e^{\theta-b_i}}{1+e^{\theta-b_i}}.
+$$
+
 Since $\frac{d}{d\theta}P_i(\theta) = P_i(\theta)(1-P_i(\theta))$ (standard logistic derivative), the score is
-$$ U(\theta) = \frac{d\ell}{d\theta} = \sum_i \left[\frac{x_i}{P_i}-\frac{1-x_i}{1-P_i}\right]P_i(1-P_i) = \sum_i\big(x_i - P_i(\theta)\big). $$
+
+$$
+U(\theta) = \frac{d\ell}{d\theta} = \sum_i \left[\frac{x_i}{P_i}-\frac{1-x_i}{1-P_i}\right]P_i(1-P_i) = \sum_i\big(x_i - P_i(\theta)\big).
+$$
+
 The observed information is $-\frac{d^2\ell}{d\theta^2} = \sum_i P_i(\theta)(1-P_i(\theta))$, which does not depend on $x_i$, so observed and expected (Fisher) information coincide: $I(\theta) = \sum_i P_i(1-P_i)$.
 
 Newton-Raphson/Fisher scoring: $\theta^{(t+1)} = \theta^{(t)} + U(\theta^{(t)})/I(\theta^{(t)})$.
 
 Now consider ordinary logistic regression of binary outcomes $x_i$ on an intercept-only model with a known offset $-b_i$: $\text{logit}(P_i) = \theta - b_i$ (i.e., $\theta$ is the only free parameter, $-b_i$ is a fixed offset per observation). The GLM score and Fisher information for the single parameter $\theta$ are, by the standard logistic regression formulas $U(\theta)=\sum_i (x_i-P_i)\cdot \partial \eta_i/\partial\theta$ and $I(\theta) = \sum_i P_i(1-P_i)(\partial\eta_i/\partial\theta)^2$ with $\partial\eta_i/\partial\theta=1$, exactly
-$$ U(\theta) = \sum_i(x_i-P_i), \qquad I(\theta)=\sum_i P_i(1-P_i), $$
+
+$$
+U(\theta) = \sum_i(x_i-P_i), \qquad I(\theta)=\sum_i P_i(1-P_i),
+$$
+
 identical to the Rasch ability score and information. Hence estimating a single examinee's Rasch ability by Newton-Raphson is literally fitting an intercept-only logistic regression with known item-difficulty offsets, and the update formulas coincide term for term.
 
 </details>
@@ -119,11 +187,23 @@ Prove that in the Rasch model, the raw score $S = \sum_{i=1}^K X_i$ is a suffici
 <summary>Solution</summary>
 
 The joint probability of a response pattern $x=(x_1,\dots,x_K)$ under local independence is
-$$ P(X=x\mid\theta) = \prod_{i=1}^K \left(\frac{e^{\theta-b_i}}{1+e^{\theta-b_i}}\right)^{x_i}\left(\frac{1}{1+e^{\theta-b_i}}\right)^{1-x_i} = \frac{\prod_i e^{x_i(\theta-b_i)}}{\prod_i(1+e^{\theta-b_i})}. $$
+
+$$
+P(X=x\mid\theta) = \prod_{i=1}^K \left(\frac{e^{\theta-b_i}}{1+e^{\theta-b_i}}\right)^{x_i}\left(\frac{1}{1+e^{\theta-b_i}}\right)^{1-x_i} = \frac{\prod_i e^{x_i(\theta-b_i)}}{\prod_i(1+e^{\theta-b_i})}.
+$$
+
 Expand the numerator:
-$$ \prod_i e^{x_i(\theta-b_i)} = \exp\left(\theta\sum_i x_i - \sum_i x_i b_i\right) = e^{\theta S}\, e^{-\sum_i x_ib_i}. $$
+
+$$
+\prod_i e^{x_i(\theta-b_i)} = \exp\left(\theta\sum_i x_i - \sum_i x_i b_i\right) = e^{\theta S}\, e^{-\sum_i x_ib_i}.
+$$
+
 So
-$$ P(X=x\mid\theta) = \underbrace{e^{\theta S}}_{\text{depends on }x\text{ only through }S}\cdot \underbrace{e^{-\sum_i x_ib_i}}_{h(x),\ \text{free of }\theta}\cdot\underbrace{\Big[\prod_i(1+e^{\theta-b_i})\Big]^{-1}}_{c(\theta),\ \text{free of }x}. $$
+
+$$
+P(X=x\mid\theta) = \underbrace{e^{\theta S}}_{\text{depends on }x\text{ only through }S}\cdot \underbrace{e^{-\sum_i x_ib_i}}_{h(x),\ \text{free of }\theta}\cdot\underbrace{\Big[\prod_i(1+e^{\theta-b_i})\Big]^{-1}}_{c(\theta),\ \text{free of }x}.
+$$
+
 This is exactly the exponential-family factorization $P(X=x\mid\theta) = g(S,\theta)\,h(x)$ with $g(S,\theta) = e^{\theta S}c(\theta)$. By the Fisher-Neyman factorization theorem, $S=\sum_i X_i$ is a sufficient statistic for $\theta$. (Note this relies critically on the Rasch model's additive $\theta - b_i$ form with a common coefficient of $1$ on $\theta$ for every item; in the 2PL model the coefficient is $a_i$, so the exponent becomes $\theta\sum_i a_ix_i$, meaning the *weighted* score $\sum_i a_i x_i$, not the raw score, would be sufficient, and since the $a_i$ are generally unknown/estimated this sufficiency is not usable in practice, which is why raw-score sufficiency is considered a special, prized property of the Rasch model.)
 
 </details>
@@ -136,11 +216,19 @@ Sketch the derivation of the EM algorithm's E-step for marginal maximum likeliho
 <summary>Solution</summary>
 
 By Bayes' theorem, the posterior density of $\theta_j$ given the response pattern $x_j$ and current item-parameter estimates $\xi^{(t)}$ is
-$$ h(\theta \mid x_j, \xi^{(t)}) = \frac{\prod_{i=1}^K P_i(\theta;\xi_i^{(t)})^{x_{ij}}\big(1-P_i(\theta;\xi_i^{(t)})\big)^{1-x_{ij}}\; g(\theta)}{\int \prod_{i=1}^K P_i(\theta';\xi_i^{(t)})^{x_{ij}}\big(1-P_i(\theta';\xi_i^{(t)})\big)^{1-x_{ij}}\; g(\theta')\, d\theta'}, $$
+
+$$
+h(\theta \mid x_j, \xi^{(t)}) = \frac{\prod_{i=1}^K P_i(\theta;\xi_i^{(t)})^{x_{ij}}\big(1-P_i(\theta;\xi_i^{(t)})\big)^{1-x_{ij}}\; g(\theta)}{\int \prod_{i=1}^K P_i(\theta';\xi_i^{(t)})^{x_{ij}}\big(1-P_i(\theta';\xi_i^{(t)})\big)^{1-x_{ij}}\; g(\theta')\, d\theta'},
+$$
+
 i.e. the likelihood of the observed pattern at ability $\theta$, times the population prior $g(\theta)$, normalized. This follows directly from Bayes' rule applied to the joint density of $(\theta_j, x_j)$ implied by the MMLE model (person ability random with density $g$, response pattern conditionally generated by the IRT model given $\theta_j$).
 
 The complete-data log-likelihood (if $\theta_j$ were observed) would be $\sum_j \sum_i \big[x_{ij}\log P_i(\theta_j)+(1-x_{ij})\log(1-P_i(\theta_j))\big]$, linear in indicator-type sufficient statistics for each item. The E-step replaces this by its expectation under $h(\theta\mid x_j,\xi^{(t)})$ for each examinee, i.e., needs $E_{h}[\log P_i(\theta)]$-type terms, which requires evaluating $\int \log P_i(\theta) \, h(\theta\mid x_j,\xi^{(t)})\, d\theta$. Since this integral has no closed form for logistic ICCs, **Gauss-Hermite quadrature** approximates it (and the normalizing integral) by a finite weighted sum over fixed nodes $\theta_1^*,\dots,\theta_Q^*$ with quadrature weights $w_1,\dots,w_Q$ chosen to integrate polynomials (times a Gaussian kernel) exactly:
-$$ \int f(\theta)g(\theta)\,d\theta \approx \sum_{q=1}^Q w_q\, f(\theta_q^*). $$
+
+$$
+\int f(\theta)g(\theta)\,d\theta \approx \sum_{q=1}^Q w_q\, f(\theta_q^*).
+$$
+
 Concretely, for each examinee $j$ and each node $q$, compute the likelihood $L(x_j\mid\theta_q^*,\xi^{(t)})$, form the discretized posterior weight $\pi_{jq} \propto w_q L(x_j\mid\theta_q^*,\xi^{(t)})\,g(\theta_q^*)$ (normalized over $q$), and accumulate, for each item $i$, the "expected number of examinees at node $q$" and "expected number correct at node $q$" by summing $\pi_{jq}$ and $\pi_{jq}x_{ij}$ over $j$. The M-step then treats these accumulated pseudo-counts at each of the $Q$ ability nodes as binomial data and updates each item's parameters $\xi_i$ by (weighted) logistic regression of expected-correct-count on the quadrature-node abilities. Iterating E and M steps converges to the MMLE item parameter estimates, exactly analogous to the EM algorithm used for GLMMs with a random intercept integrated out via quadrature.
 
 </details>
@@ -153,7 +241,11 @@ Stratum 1 (n=55): Reference correct = 20, Reference incorrect = 10; Focal correc
 Stratum 2 (n=58): Reference correct = 25, Reference incorrect = 5; Focal correct = 20, Focal incorrect = 8.
 
 Compute the Mantel-Haenszel common odds ratio
-$$ OR_{MH} = \frac{\sum_k n_{R1k}n_{F0k}/n_{Tk}}{\sum_k n_{F1k}n_{R0k}/n_{Tk}} $$
+
+$$
+OR_{MH} = \frac{\sum_k n_{R1k}n_{F0k}/n_{Tk}}{\sum_k n_{F1k}n_{R0k}/n_{Tk}}
+$$
+
 and interpret the result for DIF.
 
 <details>
@@ -170,9 +262,18 @@ Label within stratum $k$: $n_{R1k}$ = reference correct, $n_{R0k}$ = reference i
 - Denominator term: $20\times5/58 = 100/58 = 1.7241$
 
 Summing:
-$$ \sum_k n_{R1k}n_{F0k}/n_{Tk} = 5.4545+3.4483 = 8.9028 $$
-$$ \sum_k n_{F1k}n_{R0k}/n_{Tk} = 1.8182+1.7241 = 3.5423 $$
-$$ OR_{MH} = \frac{8.9028}{3.5423} = 2.513. $$
+
+$$
+\sum_k n_{R1k}n_{F0k}/n_{Tk} = 5.4545+3.4483 = 8.9028
+$$
+
+$$
+\sum_k n_{F1k}n_{R0k}/n_{Tk} = 1.8182+1.7241 = 3.5423
+$$
+
+$$
+OR_{MH} = \frac{8.9028}{3.5423} = 2.513.
+$$
 
 Interpretation: after stratifying on ability (approximated by score group), reference-group examinees have about $2.5\times$ the odds of answering the item correctly compared to focal-group examinees at the same ability level. Since $OR_{MH}$ is far from 1 (a common rule of thumb, the ETS classification, flags $|\Delta MH| $ corresponding to $OR_{MH}$ outside roughly $(0.53, 1.9)$ or wider bounds as at least moderate DIF), this item shows evidence of uniform DIF favoring the reference group and would be a candidate for review or removal from the operational item bank.
 

--- a/docs/source/Statistics301/chapter_03_advanced_modeling/lessons/L03_nonparametric_and_semiparametric_methods.md
+++ b/docs/source/Statistics301/chapter_03_advanced_modeling/lessons/L03_nonparametric_and_semiparametric_methods.md
@@ -9,22 +9,41 @@ The t-test, ANOVA, and linear regression from Statistics 1 and 2 rest on distrib
 ### Wilcoxon signed-rank test
 
 For paired data (or one sample) testing symmetry of the differences $d_1,\dots,d_n$ about 0, rank $|d_1|,\dots,|d_n|$ from smallest (rank 1) to largest, and let $W^+$ be the sum of ranks belonging to positive $d_i$. Under $H_0$ (distribution of $d_i$ symmetric about 0), each rank is independently equally likely to belong to a positive or negative difference, giving
-$$ E[W^+] = \frac{n(n+1)}{4}, \qquad Var(W^+) = \frac{n(n+1)(2n+1)}{24}. $$
+
+$$
+E[W^+] = \frac{n(n+1)}{4}, \qquad Var(W^+) = \frac{n(n+1)(2n+1)}{24}.
+$$
+
 For moderate/large $n$, $Z = (W^+ - E[W^+])/\sqrt{Var(W^+)}$ is approximately standard normal.
 
 ### Mann-Whitney U / Wilcoxon rank-sum test
 
 For two independent samples $X_1,\dots,X_{n_1}$ and $Y_1,\dots,Y_{n_2}$, testing equality of distributions against a shift alternative, define
-$$ U = \sum_{i=1}^{n_1}\sum_{j=1}^{n_2} \mathbb{1}(X_i>Y_j). $$
+
+$$
+U = \sum_{i=1}^{n_1}\sum_{j=1}^{n_2} \mathbb{1}(X_i>Y_j).
+$$
+
 $U$ relates to the rank-sum $R_1$ of the $X$'s in the pooled sample by $U = R_1 - n_1(n_1+1)/2$. Under $H_0$,
-$$ E[U] = \frac{n_1n_2}{2}, \qquad Var(U) = \frac{n_1n_2(n_1+n_2+1)}{12}. $$
+
+$$
+E[U] = \frac{n_1n_2}{2}, \qquad Var(U) = \frac{n_1n_2(n_1+n_2+1)}{12}.
+$$
 
 ### Asymptotic relative efficiency vs. the t-test
 
 The **Pitman asymptotic relative efficiency** compares the sample sizes two tests need for the same asymptotic power against local alternatives; $ARE(A,B)=2$ means test $B$ needs twice the sample size of $A$ for equivalent power. For the Wilcoxon signed-rank test against the (paired) t-test, for a symmetric density $f$ with variance $\sigma_f^2$,
-$$ ARE(W,t) = 12\,\sigma_f^2\left(\int_{-\infty}^{\infty} f(x)^2\,dx\right)^2. $$
+
+$$
+ARE(W,t) = 12\,\sigma_f^2\left(\int_{-\infty}^{\infty} f(x)^2\,dx\right)^2.
+$$
+
 For $f = N(0,\sigma^2)$: $\int f^2\,dx = \frac{1}{2\sigma\sqrt\pi}$, so
-$$ ARE(W,t) = 12\sigma^2\left(\frac{1}{2\sigma\sqrt\pi}\right)^2 = \frac{12}{4\pi} = \frac{3}{\pi} \approx 0.955. $$
+
+$$
+ARE(W,t) = 12\sigma^2\left(\frac{1}{2\sigma\sqrt\pi}\right)^2 = \frac{12}{4\pi} = \frac{3}{\pi} \approx 0.955.
+$$
+
 Remarkably, under exact normality the Wilcoxon test loses only about 4.5% asymptotic efficiency relative to the (optimal, under normality) t-test. Under other distributions the comparison can favor Wilcoxon substantially: the classical table of values is Normal $3/\pi \approx 0.955$, Uniform $1.0$, Logistic $\pi^2/9\approx1.097$, Double-exponential (Laplace) $1.5$, and for the Cauchy distribution the ARE is unbounded (the t-test's efficiency collapses because sample means of Cauchy variables do not even have finite variance, while rank tests remain well-behaved). This is the standard justification for preferring rank tests when normality is doubtful: bounded downside (about 5% under normality), unbounded upside under heavy tails.
 
 ## Kernel Density Estimation
@@ -32,19 +51,39 @@ Remarkably, under exact normality the Wilcoxon test loses only about 4.5% asympt
 ### Definition, bias, and variance
 
 Given iid $X_1,\dots,X_n \sim f$, the kernel density estimator with bandwidth $h$ and kernel $K$ (a symmetric density) is
-$$ \hat f_h(x) = \frac{1}{nh}\sum_{i=1}^n K\!\left(\frac{x-X_i}{h}\right). $$
+
+$$
+\hat f_h(x) = \frac{1}{nh}\sum_{i=1}^n K\!\left(\frac{x-X_i}{h}\right).
+$$
+
 A second-order Taylor expansion of $f$ around $x$ inside $E[\hat f_h(x)]$ gives, for small $h$,
-$$ Bias\big(\hat f_h(x)\big) \approx \frac{h^2}{2} f''(x)\, \mu_2(K), \qquad \mu_2(K) = \int u^2K(u)\,du, $$
+
+$$
+Bias\big(\hat f_h(x)\big) \approx \frac{h^2}{2} f''(x)\, \mu_2(K), \qquad \mu_2(K) = \int u^2K(u)\,du,
+$$
+
 and a standard variance calculation gives
-$$ Var\big(\hat f_h(x)\big) \approx \frac{f(x)}{nh}\, R(K), \qquad R(K) = \int K(u)^2\,du. $$
+
+$$
+Var\big(\hat f_h(x)\big) \approx \frac{f(x)}{nh}\, R(K), \qquad R(K) = \int K(u)^2\,du.
+$$
+
 Bias grows with $h$ (more smoothing washes out curvature) while variance shrinks with $h$ (more data points contribute to each local average): the classic bias-variance tradeoff.
 
 ### MISE and the optimal bandwidth
 
 The mean integrated squared error is
-$$ MISE(h) = \int E\big[(\hat f_h(x)-f(x))^2\big]dx \approx \underbrace{\frac{h^4}{4}\mu_2(K)^2\int f''(x)^2\,dx}_{\text{integrated squared bias}} + \underbrace{\frac{R(K)}{nh}}_{\text{integrated variance}}. $$
+
+$$
+MISE(h) = \int E\big[(\hat f_h(x)-f(x))^2\big]dx \approx \underbrace{\frac{h^4}{4}\mu_2(K)^2\int f''(x)^2\,dx}_{\text{integrated squared bias}} + \underbrace{\frac{R(K)}{nh}}_{\text{integrated variance}}.
+$$
+
 Differentiating with respect to $h$ and setting to zero gives the asymptotically optimal bandwidth
-$$ h_{opt} = \left[\frac{R(K)}{\mu_2(K)^2 \int f''(x)^2\,dx \cdot n}\right]^{1/5} = O(n^{-1/5}), $$
+
+$$
+h_{opt} = \left[\frac{R(K)}{\mu_2(K)^2 \int f''(x)^2\,dx \cdot n}\right]^{1/5} = O(n^{-1/5}),
+$$
+
 and plugging back in, $AMISE(h_{opt}) = O(n^{-4/5})$. This is slower than the parametric rate $O(n^{-1})$: nonparametric density estimation pays a price in convergence rate for not assuming a parametric family, which is the generic phenomenon behind "the curse of dimensionality" in nonparametric statistics.
 
 ## Local Regression and Smoothing Splines
@@ -52,24 +91,47 @@ and plugging back in, $AMISE(h_{opt}) = O(n^{-4/5})$. This is slower than the pa
 ### Nadaraya-Watson estimator
 
 For regression data $(X_i,Y_i)$, $i=1,\dots,n$, with $Y_i = m(X_i)+\epsilon_i$, the Nadaraya-Watson (local constant) estimator is a kernel-weighted local average:
-$$ \hat m(x) = \frac{\sum_{i=1}^n K_h(x-X_i)\,Y_i}{\sum_{i=1}^n K_h(x-X_i)}, \qquad K_h(u)=K(u/h)/h. $$
+
+$$
+\hat m(x) = \frac{\sum_{i=1}^n K_h(x-X_i)\,Y_i}{\sum_{i=1}^n K_h(x-X_i)}, \qquad K_h(u)=K(u/h)/h.
+$$
+
 This estimator has known boundary bias (near the edges of the covariate range the kernel window is asymmetric). **Local linear regression** corrects this by fitting a weighted least-squares line locally rather than a constant:
-$$ (\hat a,\hat b) = \arg\min_{a,b}\sum_{i=1}^n K_h(x-X_i)\big(Y_i-a-b(X_i-x)\big)^2, \qquad \hat m(x)=\hat a. $$
+
+$$
+(\hat a,\hat b) = \arg\min_{a,b}\sum_{i=1}^n K_h(x-X_i)\big(Y_i-a-b(X_i-x)\big)^2, \qquad \hat m(x)=\hat a.
+$$
+
 Locally weighting by a line rather than a constant cancels the leading bias term at boundaries and reduces bias in regions of curvature.
 
 ### Smoothing splines
 
 An alternative formulation directly penalizes roughness. The smoothing spline estimator solves the penalized least-squares problem over all twice-differentiable functions $m$:
-$$ \hat m = \arg\min_{m}\ \sum_{i=1}^n \big(Y_i - m(X_i)\big)^2 + \lambda \int \big(m''(t)\big)^2\,dt, $$
+
+$$
+\hat m = \arg\min_{m}\ \sum_{i=1}^n \big(Y_i - m(X_i)\big)^2 + \lambda \int \big(m''(t)\big)^2\,dt,
+$$
+
 where $\lambda \geq 0$ is the smoothing parameter. As $\lambda\to0$, $\hat m$ interpolates the data (a natural cubic spline through every point); as $\lambda\to\infty$, the penalty forces $m''\equiv0$, i.e., $\hat m$ becomes the OLS regression line. It is a classical result that the minimizer, for any $\lambda>0$, is a **natural cubic spline** with knots at the distinct $X_i$ values. The fitted values are a linear smoother, $\hat Y = S_\lambda Y$, and the **effective degrees of freedom** are $df_\lambda = tr(S_\lambda)$, generalizing the notion of "number of parameters" to a continuously tunable amount of flexibility. $\lambda$ is typically chosen by generalized cross-validation,
-$$ GCV(\lambda) = \frac{n^{-1}\sum_i (Y_i-\hat m_\lambda(X_i))^2}{\big(1-tr(S_\lambda)/n\big)^2}. $$
+
+$$
+GCV(\lambda) = \frac{n^{-1}\sum_i (Y_i-\hat m_\lambda(X_i))^2}{\big(1-tr(S_\lambda)/n\big)^2}.
+$$
 
 ### Semiparametric partial linear models (brief)
 
 Sometimes we want the interpretability of a linear effect for covariates of primary interest while flexibly adjusting for a nuisance covariate:
-$$ Y_i = X_i^T\beta + g(T_i) + \epsilon_i, $$
+
+$$
+Y_i = X_i^T\beta + g(T_i) + \epsilon_i,
+$$
+
 with $g(\cdot)$ an unspecified smooth function. Robinson's (1988) double-residual estimator profiles out $g$: regress (nonparametrically, e.g., via kernel smoothing) $Y$ on $T$ and each column of $X$ on $T$, take residuals $\tilde Y_i = Y_i - \hat E[Y\mid T_i]$ and $\tilde X_i = X_i-\hat E[X\mid T_i]$, then run OLS of $\tilde Y$ on $\tilde X$:
-$$ \hat\beta = \left(\sum_i \tilde X_i \tilde X_i^T\right)^{-1}\sum_i \tilde X_i \tilde Y_i. $$
+
+$$
+\hat\beta = \left(\sum_i \tilde X_i \tilde X_i^T\right)^{-1}\sum_i \tilde X_i \tilde Y_i.
+$$
+
 Remarkably, $\hat\beta$ is $\sqrt n$-consistent and asymptotically normal for $\beta$, at the parametric rate, despite $g$ being estimated only at the slower nonparametric rate; this is the hallmark "semiparametric efficiency" phenomenon: the parameter of interest is unaffected in its rate of convergence by the presence of an infinite-dimensional nuisance parameter, provided that nuisance is estimated consistently.
 
 ## Worked Example
@@ -79,9 +141,19 @@ Paired differences (treatment minus control) for $n=6$ subjects: $d = (2,\,-1,\,
 Absolute values and ranks: $|d| = (2,1,3,4,0.5,1.5)$, sorted $0.5<1<1.5<2<3<4$, so ranks are: $d=-0.5\to$ rank 1, $d=-1\to$ rank 2, $d=1.5\to$ rank 3, $d=2\to$ rank 4, $d=3\to$ rank 5, $d=4\to$ rank 6.
 
 Positive differences are $2, 3, 4, 1.5$ with ranks $4,5,6,3$, so
-$$ W^+ = 4+5+6+3 = 18. $$
-$$ E[W^+] = \frac{6\times7}{4} = 10.5, \qquad Var(W^+) = \frac{6\times7\times13}{24} = \frac{546}{24} = 22.75. $$
-$$ Z = \frac{18-10.5}{\sqrt{22.75}} = \frac{7.5}{4.7697} = 1.572. $$
+
+$$
+W^+ = 4+5+6+3 = 18.
+$$
+
+$$
+E[W^+] = \frac{6\times7}{4} = 10.5, \qquad Var(W^+) = \frac{6\times7\times13}{24} = \frac{546}{24} = 22.75.
+$$
+
+$$
+Z = \frac{18-10.5}{\sqrt{22.75}} = \frac{7.5}{4.7697} = 1.572.
+$$
+
 Two-sided p-value $\approx 2(1-\Phi(1.572)) = 2(0.058) = 0.116$: not significant at $\alpha=0.05$ despite five of six differences being positive, illustrating how the small sample size limits power even for a robust test.
 
 ```python
@@ -99,13 +171,23 @@ Derive $E[W^+]$ and $Var(W^+)$ under $H_0$ from first principles, using the repr
 <summary>Solution</summary>
 
 Under $H_0$ (the distribution of each $d_k$ is symmetric about 0), the sign of $d_k$ is independent of $|d_k|$, and by symmetry each sign is an independent fair coin flip: $P(\text{sign}=+)=P(\text{sign}=-)=1/2$, independently across the $n$ observations, *regardless of* the ranks of the $|d_k|$'s. Consequently, if we let $\psi_i \in \{0,1\}$ denote the sign attached to the observation whose $|d|$ has rank $i$ (for $i=1,\dots,n$), the $\psi_i$ are iid $Bernoulli(1/2)$, independent of which observation got which rank. Then
-$$ W^+ = \sum_{i=1}^n i\,\psi_i. $$
+
+$$
+W^+ = \sum_{i=1}^n i\,\psi_i.
+$$
 
 **Mean:**
-$$ E[W^+] = \sum_{i=1}^n i\, E[\psi_i] = \sum_{i=1}^n i\cdot\frac12 = \frac12\cdot\frac{n(n+1)}{2} = \frac{n(n+1)}{4}. $$
+
+$$
+E[W^+] = \sum_{i=1}^n i\, E[\psi_i] = \sum_{i=1}^n i\cdot\frac12 = \frac12\cdot\frac{n(n+1)}{2} = \frac{n(n+1)}{4}.
+$$
 
 **Variance:** since the $\psi_i$ are independent, $Var(W^+) = \sum_{i=1}^n i^2\,Var(\psi_i)$. For $\psi_i\sim Bernoulli(1/2)$, $Var(\psi_i) = \tfrac12(1-\tfrac12)=\tfrac14$. So
-$$ Var(W^+) = \frac14 \sum_{i=1}^n i^2 = \frac14\cdot\frac{n(n+1)(2n+1)}{6} = \frac{n(n+1)(2n+1)}{24}, $$
+
+$$
+Var(W^+) = \frac14 \sum_{i=1}^n i^2 = \frac14\cdot\frac{n(n+1)(2n+1)}{6} = \frac{n(n+1)(2n+1)}{24},
+$$
+
 using the standard identity $\sum_{i=1}^n i^2 = n(n+1)(2n+1)/6$. Both formulas match the ones quoted in the notes.
 
 </details>
@@ -120,15 +202,31 @@ Derive $E[U]$ and $Var(U)$ for the Mann-Whitney statistic under $H_0$ (both samp
 Let $N=n_1+n_2$. Under $H_0$, the $N$ observations are exchangeable, so the set of ranks $1,\dots,N$ assigned to the $X$-sample is a uniformly random subset of size $n_1$ out of $N$ (all $\binom{N}{n_1}$ subsets equally likely). Write $R_1 = \sum_{i=1}^{n_1} \text{rank}(X_i)$ for the rank sum of the $X$'s, and recall $U = R_1 - n_1(n_1+1)/2$.
 
 **Mean of $R_1$:** each of the $N$ ranks $1,\dots,N$ is equally likely to be any particular rank value, and by symmetry each individual $X_i$'s rank has the same marginal distribution as a single rank drawn uniformly from $\{1,\dots,N\}$ (this follows from the exchangeability/uniform-subset argument: the marginal probability that any specific rank value $r$ is assigned to *some* $X$ is $n_1/N$, and by symmetry this is spread equally over which $X_i$ gets it). So
-$$ E[R_1] = n_1 \cdot E[\text{rank}] = n_1\cdot \frac{N+1}{2}. $$
+
+$$
+E[R_1] = n_1 \cdot E[\text{rank}] = n_1\cdot \frac{N+1}{2}.
+$$
+
 Then
-$$ E[U] = E[R_1] - \frac{n_1(n_1+1)}{2} = n_1\frac{N+1}{2} - \frac{n_1(n_1+1)}{2} = \frac{n_1}{2}\big[(N+1)-(n_1+1)\big] = \frac{n_1}{2}(N-n_1) = \frac{n_1n_2}{2}, $$
+
+$$
+E[U] = E[R_1] - \frac{n_1(n_1+1)}{2} = n_1\frac{N+1}{2} - \frac{n_1(n_1+1)}{2} = \frac{n_1}{2}\big[(N+1)-(n_1+1)\big] = \frac{n_1}{2}(N-n_1) = \frac{n_1n_2}{2},
+$$
+
 using $N-n_1=n_2$.
 
 **Variance of $R_1$:** $R_1$ is the sum of $n_1$ values drawn *without replacement* from $\{1,\dots,N\}$. For sampling without replacement, the variance of a sum of $n_1$ draws from a finite population of size $N$ with population variance $\sigma_P^2 = \frac{1}{N}\sum_{r=1}^N (r-\bar r)^2 = \frac{N^2-1}{12}$ (variance of a discrete uniform on $1,\dots,N$) is
-$$ Var(R_1) = n_1\sigma_P^2\cdot\frac{N-n_1}{N-1} = n_1\cdot\frac{N^2-1}{12}\cdot\frac{n_2}{N-1} = \frac{n_1n_2(N+1)}{12}, $$
+
+$$
+Var(R_1) = n_1\sigma_P^2\cdot\frac{N-n_1}{N-1} = n_1\cdot\frac{N^2-1}{12}\cdot\frac{n_2}{N-1} = \frac{n_1n_2(N+1)}{12},
+$$
+
 using $(N^2-1)/(N-1) = N+1$. Since $U = R_1 - \text{const}$, $Var(U)=Var(R_1)$, so
-$$ Var(U) = \frac{n_1n_2(n_1+n_2+1)}{12}, $$
+
+$$
+Var(U) = \frac{n_1n_2(n_1+n_2+1)}{12},
+$$
+
 matching the notes.
 
 </details>
@@ -143,17 +241,37 @@ Derive the bias formula $Bias(\hat f_h(x)) \approx \frac{h^2}{2}f''(x)\mu_2(K)$ 
 By definition, $E[\hat f_h(x)] = E\left[\frac1h K\left(\frac{x-X}{h}\right)\right] = \int \frac1h K\left(\frac{x-u}{h}\right) f(u)\, du$ (using that the $X_i$ are iid with density $f$, and linearity of expectation over the sum of $n$ identical terms divided by $n$).
 
 Substitute $u = x - ht$ (so $t = (x-u)/h$, $du = -h\,dt$; as $u$ ranges over $\mathbb{R}$, so does $t$, with the sign flip absorbed by reversing limits):
-$$ E[\hat f_h(x)] = \int K(t)\, f(x-ht)\, dt. $$
+
+$$
+E[\hat f_h(x)] = \int K(t)\, f(x-ht)\, dt.
+$$
+
 Assume $f$ is twice continuously differentiable in a neighborhood of $x$ with bounded second derivative, and $K$ is a symmetric density with $\int K(t)dt=1$, $\int tK(t)\,dt=0$ (symmetry), $\int t^2K(t)\,dt = \mu_2(K) < \infty$. Taylor-expand $f(x-ht)$ around $t=0$ (i.e., around the point $x$):
-$$ f(x-ht) = f(x) - ht f'(x) + \frac{h^2t^2}{2}f''(x) + o(h^2) $$
+
+$$
+f(x-ht) = f(x) - ht f'(x) + \frac{h^2t^2}{2}f''(x) + o(h^2)
+$$
+
 uniformly for $t$ in the support where $K$ has appreciable mass (standard regularity: $h\to 0$ as $n\to\infty$, and $K$ has compact support or sufficiently thin tails so the remainder integrates to $o(h^2)$).
 
 Integrate term by term against $K(t)\,dt$:
-$$ E[\hat f_h(x)] = f(x)\int K(t)\,dt - hf'(x)\int tK(t)\,dt + \frac{h^2}{2}f''(x)\int t^2K(t)\,dt + o(h^2). $$
+
+$$
+E[\hat f_h(x)] = f(x)\int K(t)\,dt - hf'(x)\int tK(t)\,dt + \frac{h^2}{2}f''(x)\int t^2K(t)\,dt + o(h^2).
+$$
+
 The first integral is 1, the second is 0 by symmetry of $K$, and the third is $\mu_2(K)$ by definition. So
-$$ E[\hat f_h(x)] = f(x) + \frac{h^2}{2}f''(x)\mu_2(K) + o(h^2), $$
+
+$$
+E[\hat f_h(x)] = f(x) + \frac{h^2}{2}f''(x)\mu_2(K) + o(h^2),
+$$
+
 and therefore
-$$ Bias(\hat f_h(x)) = E[\hat f_h(x)] - f(x) \approx \frac{h^2}{2}f''(x)\mu_2(K), $$
+
+$$
+Bias(\hat f_h(x)) = E[\hat f_h(x)] - f(x) \approx \frac{h^2}{2}f''(x)\mu_2(K),
+$$
+
 as claimed. The bias is largest in magnitude where $|f''(x)|$ is largest (near peaks and troughs of the density) and vanishes as $h\to0$, at rate $O(h^2)$.
 
 </details>
@@ -179,7 +297,9 @@ Sum of weights: $0.05399+0.24197+0.39894+0.24197+0.05399 = 0.99086$.
 
 Sum of weighted $Y$: $0.10798+0.72591+1.99470+0.96788+0.32394 = 4.12041$.
 
-$$ \hat m(3) = \frac{\sum_i K(u_i)Y_i}{\sum_i K(u_i)} = \frac{4.12041}{0.99086} = 4.158. $$
+$$
+\hat m(3) = \frac{\sum_i K(u_i)Y_i}{\sum_i K(u_i)} = \frac{4.12041}{0.99086} = 4.158.
+$$
 
 The estimate 4.158 is close to but not exactly $Y_3=5$ or the simple average of neighbors, because the Gaussian kernel gives substantial (though declining) weight to $X=2$ and $X=4$ and smaller weight to the more distant points $X=1,5$, pulling the local average down from $Y_3=5$ toward the neighboring values $3$ and $4$.
 

--- a/docs/source/Statistics301/chapter_03_advanced_modeling/lessons/L04_survival_analysis.md
+++ b/docs/source/Statistics301/chapter_03_advanced_modeling/lessons/L04_survival_analysis.md
@@ -13,11 +13,23 @@ Time-to-event data, time until death, machine failure, customer churn, disease r
 ### Definitions and relations
 
 Let $T\geq0$ be the (possibly unobserved) event time with density $f(t)$ and CDF $F(t)$. The **survival function** is
-$$ S(t) = P(T>t) = 1-F(t). $$
+
+$$
+S(t) = P(T>t) = 1-F(t).
+$$
+
 The **hazard function** is the instantaneous event rate given survival to $t$:
-$$ h(t) = \lim_{\Delta t\to 0} \frac{P(t\leq T<t+\Delta t \mid T\geq t)}{\Delta t} = \frac{f(t)}{S(t)}. $$
+
+$$
+h(t) = \lim_{\Delta t\to 0} \frac{P(t\leq T<t+\Delta t \mid T\geq t)}{\Delta t} = \frac{f(t)}{S(t)}.
+$$
+
 Since $f(t) = -S'(t)$, we have $h(t) = -S'(t)/S(t) = -\frac{d}{dt}\log S(t)$. Integrating,
-$$ H(t) = \int_0^t h(u)\,du = -\log S(t) \quad\Longleftrightarrow\quad S(t) = \exp\big(-H(t)\big), $$
+
+$$
+H(t) = \int_0^t h(u)\,du = -\log S(t) \quad\Longleftrightarrow\quad S(t) = \exp\big(-H(t)\big),
+$$
+
 where $H(t)$ is the **cumulative hazard function**. These identities let us move freely between $f$, $S$, $h$, and $H$: e.g. $f(t) = h(t)S(t) = h(t)\exp(-H(t))$.
 
 ## Kaplan-Meier Estimator and Greenwood's Formula
@@ -25,15 +37,27 @@ where $H(t)$ is the **cumulative hazard function**. These identities let us move
 ### Derivation of the KM estimator
 
 Let $t_{(1)}<t_{(2)}<\dots<t_{(k)}$ be the distinct observed **event** times. At $t_{(j)}$, let $n_j$ be the number of subjects still at risk (neither having had the event nor been censored before $t_{(j)}$) and $d_j$ the number of events occurring exactly at $t_{(j)}$. Model the survival process via discrete hazards $\lambda_j = P(\text{event at } t_{(j)} \mid \text{at risk at } t_{(j)})$, one per distinct event time, and zero hazard elsewhere. Conditional on the risk sets, the number of events at $t_{(j)}$ given $n_j$ at risk is (treating individuals as exchangeable within the risk set) Binomial$(n_j,\lambda_j)$, so the nonparametric likelihood factors as
-$$ L(\lambda_1,\dots,\lambda_k) = \prod_{j=1}^k \binom{n_j}{d_j}\lambda_j^{d_j}(1-\lambda_j)^{n_j-d_j}. $$
+
+$$
+L(\lambda_1,\dots,\lambda_k) = \prod_{j=1}^k \binom{n_j}{d_j}\lambda_j^{d_j}(1-\lambda_j)^{n_j-d_j}.
+$$
+
 This factors into separate terms for each $j$, so maximizing over each $\lambda_j$ independently gives the ordinary binomial MLE $\hat\lambda_j = d_j/n_j$. Since $S(t) = \prod_{j: t_{(j)}\leq t}(1-\lambda_j)$ under this discrete-hazard construction (the probability of surviving past $t$ is the probability of surviving each intervening discrete hazard), plugging in the MLEs gives the **Kaplan-Meier estimator**:
-$$ \hat S(t) = \prod_{j:\, t_{(j)}\leq t} \left(1-\frac{d_j}{n_j}\right). $$
+
+$$
+\hat S(t) = \prod_{j:\, t_{(j)}\leq t} \left(1-\frac{d_j}{n_j}\right).
+$$
+
 Censored observations enter only through the risk sets $n_j$ (they reduce $n_j$ for all later event times) and contribute no $d_j$, which is exactly the correct partial-information treatment.
 
 ### Greenwood's formula
 
 The variance of $\hat S(t)$ is obtained via the delta method applied to $\log\hat S(t) = \sum_{j:t_{(j)}\leq t}\log(1-d_j/n_j)$ (full derivation in Exercise 2):
-$$ \widehat{Var}\big(\hat S(t)\big) = \hat S(t)^2 \sum_{j:\, t_{(j)}\leq t} \frac{d_j}{n_j(n_j-d_j)}. $$
+
+$$
+\widehat{Var}\big(\hat S(t)\big) = \hat S(t)^2 \sum_{j:\, t_{(j)}\leq t} \frac{d_j}{n_j(n_j-d_j)}.
+$$
+
 This is used to build confidence intervals for $S(t)$; because the normal-approximation interval $\hat S(t)\pm z_{\alpha/2}SE$ can extend outside $[0,1]$ (especially near the tails of follow-up where few subjects remain at risk), it is common practice to construct the interval on a transformed scale (e.g. $\log(-\log S(t))$) and back-transform.
 
 ## Log-Rank Test and Cox Proportional Hazards Model
@@ -41,29 +65,53 @@ This is used to build confidence intervals for $S(t)$; because the normal-approx
 ### Log-rank test
 
 To compare survival between two groups, at each distinct event time $t_{(j)}$ (pooling both groups) form a 2x2 table of group membership by event/no-event among those at risk, and compare observed events in group 1, $O_{1j}$, to their expectation under the null hypergeometric distribution (fixing the margins, $d_j$ total events and $n_{1j}, n_{2j}$ at risk in each group):
-$$ E_{1j} = \frac{n_{1j}\,d_j}{n_j}, \qquad V_j = \frac{n_{1j}n_{2j}\,d_j\,(n_j-d_j)}{n_j^2(n_j-1)}. $$
+
+$$
+E_{1j} = \frac{n_{1j}\,d_j}{n_j}, \qquad V_j = \frac{n_{1j}n_{2j}\,d_j\,(n_j-d_j)}{n_j^2(n_j-1)}.
+$$
+
 Summing over all event times and standardizing,
-$$ Z = \frac{\sum_j (O_{1j}-E_{1j})}{\sqrt{\sum_j V_j}} \;\xrightarrow{d}\; N(0,1) \quad \text{under } H_0: S_1=S_2, $$
+
+$$
+Z = \frac{\sum_j (O_{1j}-E_{1j})}{\sqrt{\sum_j V_j}} \;\xrightarrow{d}\; N(0,1) \quad \text{under } H_0: S_1=S_2,
+$$
+
 equivalently $Z^2 \to \chi^2_1$. This is exactly a Mantel-Haenszel test stratified over the distinct event times.
 
 ### Cox proportional hazards model
 
 The Cox model specifies the hazard for an individual with covariates $x$ as
-$$ h(t\mid x) = h_0(t)\, \exp(x^T\beta), $$
+
+$$
+h(t\mid x) = h_0(t)\, \exp(x^T\beta),
+$$
+
 where $h_0(t)$ is an unspecified (nonparametric) baseline hazard, and the **proportional hazards (PH) assumption** is that the hazard ratio between any two covariate profiles, $\exp((x_1-x_2)^T\beta)$, is constant over time.
 
 ### Partial likelihood
 
 Cox's key idea eliminates the infinite-dimensional nuisance $h_0(t)$ by conditioning, at each observed event time $t_{(j)}$, on the identity of the risk set $R(t_{(j)})$ and on the fact that exactly one event occurred, asking only *which* member of the risk set it was:
-$$ P\big(\text{subject } (j) \text{ fails} \mid \text{one failure at } t_{(j)}, R(t_{(j)})\big) = \frac{h_0(t_{(j)})\exp(x_{(j)}^T\beta)}{\sum_{l\in R(t_{(j)})} h_0(t_{(j)})\exp(x_l^T\beta)} = \frac{\exp(x_{(j)}^T\beta)}{\sum_{l\in R(t_{(j)})}\exp(x_l^T\beta)}, $$
+
+$$
+P\big(\text{subject } (j) \text{ fails} \mid \text{one failure at } t_{(j)}, R(t_{(j)})\big) = \frac{h_0(t_{(j)})\exp(x_{(j)}^T\beta)}{\sum_{l\in R(t_{(j)})} h_0(t_{(j)})\exp(x_l^T\beta)} = \frac{\exp(x_{(j)}^T\beta)}{\sum_{l\in R(t_{(j)})}\exp(x_l^T\beta)},
+$$
+
 the baseline hazard cancels. Multiplying these conditional probabilities over all $k$ event times gives the **partial likelihood**
-$$ L_p(\beta) = \prod_{j=1}^k \frac{\exp(x_{(j)}^T\beta)}{\sum_{l\in R(t_{(j)})}\exp(x_l^T\beta)}. $$
+
+$$
+L_p(\beta) = \prod_{j=1}^k \frac{\exp(x_{(j)}^T\beta)}{\sum_{l\in R(t_{(j)})}\exp(x_l^T\beta)}.
+$$
+
 Maximizing $\log L_p(\beta)$ by Newton-Raphson gives $\hat\beta$, and standard likelihood asymptotics (score, Wald, and likelihood-ratio tests, using the observed information from $\log L_p$) apply even though $L_p$ is not a full likelihood, a foundational (and nontrivial) result due to Cox (1972, 1975).
 
 ### Checking the PH assumption: Schoenfeld residuals
 
 For covariate $k$ and event time $t_{(j)}$, the **Schoenfeld residual** compares the failing subject's observed covariate value to the risk-set-weighted expectation under the fitted model:
-$$ r_{jk} = x_{(j)k} - \frac{\sum_{l\in R(t_{(j)})} x_{lk}\exp(x_l^T\hat\beta)}{\sum_{l\in R(t_{(j)})}\exp(x_l^T\hat\beta)}. $$
+
+$$
+r_{jk} = x_{(j)k} - \frac{\sum_{l\in R(t_{(j)})} x_{lk}\exp(x_l^T\hat\beta)}{\sum_{l\in R(t_{(j)})}\exp(x_l^T\hat\beta)}.
+$$
+
 Under a correctly specified PH model, these residuals should fluctuate randomly around zero with no systematic trend in time. A significant correlation between (scaled) Schoenfeld residuals and time, or a function of time, formally tested via the Grambsch-Therneau test, indicates that the effect of covariate $k$ is not actually constant over time (the PH assumption is violated), suggesting remedies such as stratification, time-varying coefficients, or splitting follow-up time.
 
 ## Worked Example
@@ -86,8 +134,14 @@ Group A: 4(event), 6(event), 8(censored), 10(event). Group B: 3(event), 5(event)
 | 10 | 1 | 1 | 0/1 | 0.0000 |
 
 **Greenwood variance at $t=7$** ($\hat S(7)=0.375$):
-$$ \sum \frac{d_j}{n_j(n_j-d_j)} = \frac{1}{8\cdot7}+\frac{1}{7\cdot6}+\frac{1}{6\cdot5}+\frac{1}{5\cdot4}+\frac{1}{4\cdot3} = 0.01786+0.02381+0.03333+0.05+0.08333 = 0.20833 $$
-$$ \widehat{Var}(\hat S(7)) = 0.375^2 \times 0.20833 = 0.14063\times0.20833 = 0.02930, \qquad SE = 0.1712. $$
+
+$$
+\sum \frac{d_j}{n_j(n_j-d_j)} = \frac{1}{8\cdot7}+\frac{1}{7\cdot6}+\frac{1}{6\cdot5}+\frac{1}{5\cdot4}+\frac{1}{4\cdot3} = 0.01786+0.02381+0.03333+0.05+0.08333 = 0.20833
+$$
+
+$$
+\widehat{Var}(\hat S(7)) = 0.375^2 \times 0.20833 = 0.14063\times0.20833 = 0.02930, \qquad SE = 0.1712.
+$$
 
 **Log-rank test** (Group A vs. Group B): tracking $n_{Aj}, n_{Bj}$ at each event time (A starts with 4 at risk, B starts with 4):
 
@@ -102,8 +156,14 @@ $$ \widehat{Var}(\hat S(7)) = 0.375^2 \times 0.20833 = 0.14063\times0.20833 = 0.
 
 (Censoring at $t=8,9$ reduces risk sets but contributes no row since $d_j=0$ there.)
 
-$$ \sum (O_{Aj}-E_{Aj}) = -0.500+0.429-0.500+0.400-0.500+0 = -0.671, \qquad \sum V_j = 1.2349 $$
-$$ Z = \frac{-0.671}{\sqrt{1.2349}} = \frac{-0.671}{1.1113} = -0.604, \qquad Z^2 = 0.365. $$
+$$
+\sum (O_{Aj}-E_{Aj}) = -0.500+0.429-0.500+0.400-0.500+0 = -0.671, \qquad \sum V_j = 1.2349
+$$
+
+$$
+Z = \frac{-0.671}{\sqrt{1.2349}} = \frac{-0.671}{1.1113} = -0.604, \qquad Z^2 = 0.365.
+$$
+
 With $\chi^2_1$ reference, $p\approx0.55$: no evidence of a survival difference between groups, unsurprising given the tiny sample.
 
 ## Exercises
@@ -118,9 +178,17 @@ For $T\sim Exponential(\lambda)$ (constant hazard $h(t)=\lambda$), derive the ha
 If $h(t)=\lambda$ (constant) for all $t\geq0$, then $H(t) = \int_0^t \lambda\,du = \lambda t$, and therefore $S(t) = \exp(-H(t)) = e^{-\lambda t}$ (recovering the exponential survival function; density $f(t)=h(t)S(t)=\lambda e^{-\lambda t}$).
 
 To show memorylessness follows from constant hazard, use the conditional survival identity: for $s,t\geq0$,
-$$ P(T>s+t\mid T>s) = \frac{P(T>s+t, T>s)}{P(T>s)} = \frac{P(T>s+t)}{P(T>s)} = \frac{S(s+t)}{S(s)}, $$
+
+$$
+P(T>s+t\mid T>s) = \frac{P(T>s+t, T>s)}{P(T>s)} = \frac{P(T>s+t)}{P(T>s)} = \frac{S(s+t)}{S(s)},
+$$
+
 since $\{T>s+t\}\subseteq\{T>s\}$. Substituting the constant-hazard survival function,
-$$ \frac{S(s+t)}{S(s)} = \frac{e^{-\lambda(s+t)}}{e^{-\lambda s}} = e^{-\lambda t} = S(t) = P(T>t). $$
+
+$$
+\frac{S(s+t)}{S(s)} = \frac{e^{-\lambda(s+t)}}{e^{-\lambda s}} = e^{-\lambda t} = S(t) = P(T>t).
+$$
+
 So $P(T>s+t\mid T>s) = P(T>t)$ for all $s,t\geq 0$: having survived to time $s$ gives no information about additional survival time beyond $t$, the memoryless property, and it follows purely from $h(t)$ being constant (the hazard, "instantaneous risk given survival so far", literally does not depend on how long one has already survived, which is the mechanistic reason memorylessness holds). Conversely, one can show any absolutely continuous memoryless distribution must have $S(s+t)=S(s)S(t)$, whose only continuous solution is $S(t)=e^{-\lambda t}$ for some $\lambda\geq0$, so constant hazard and memorylessness are in fact equivalent characterizations of the exponential family among continuous distributions.
 
 </details>
@@ -133,15 +201,35 @@ Derive Greenwood's formula via the delta method, starting from $\log\hat S(t) = 
 <summary>Solution</summary>
 
 Write $\hat\lambda_j = d_j/n_j$ and $\log\hat S(t) = \sum_{j} \log(1-\hat\lambda_j)$, sum over $j$ with $t_{(j)}\leq t$. Treating $d_j \mid n_j \sim Binomial(n_j,\lambda_j)$ (approximately, conditional on the risk-set structure) and the terms across different $j$ as approximately independent (a standard martingale-based argument makes this rigorous, but the binomial-approximation route gives the same classical formula), we have
-$$ Var(\hat\lambda_j) \approx \frac{\lambda_j(1-\lambda_j)}{n_j}, $$
+
+$$
+Var(\hat\lambda_j) \approx \frac{\lambda_j(1-\lambda_j)}{n_j},
+$$
+
 the usual binomial-proportion variance. Apply the delta method to $g(\hat\lambda_j) = \log(1-\hat\lambda_j)$, with $g'(\lambda_j) = -1/(1-\lambda_j)$:
-$$ Var\big(\log(1-\hat\lambda_j)\big) \approx \big[g'(\lambda_j)\big]^2 Var(\hat\lambda_j) = \frac{1}{(1-\lambda_j)^2}\cdot\frac{\lambda_j(1-\lambda_j)}{n_j} = \frac{\lambda_j}{n_j(1-\lambda_j)}. $$
+
+$$
+Var\big(\log(1-\hat\lambda_j)\big) \approx \big[g'(\lambda_j)\big]^2 Var(\hat\lambda_j) = \frac{1}{(1-\lambda_j)^2}\cdot\frac{\lambda_j(1-\lambda_j)}{n_j} = \frac{\lambda_j}{n_j(1-\lambda_j)}.
+$$
+
 Substituting the plug-in estimate $\hat\lambda_j = d_j/n_j$ (so $1-\hat\lambda_j = (n_j-d_j)/n_j$):
-$$ \widehat{Var}\big(\log(1-\hat\lambda_j)\big) = \frac{d_j/n_j}{n_j\cdot (n_j-d_j)/n_j} = \frac{d_j}{n_j(n_j-d_j)}. $$
+
+$$
+\widehat{Var}\big(\log(1-\hat\lambda_j)\big) = \frac{d_j/n_j}{n_j\cdot (n_j-d_j)/n_j} = \frac{d_j}{n_j(n_j-d_j)}.
+$$
+
 By the assumed independence across event times, variances of the log-terms add:
-$$ \widehat{Var}\big(\log\hat S(t)\big) = \sum_{j:t_{(j)}\leq t} \frac{d_j}{n_j(n_j-d_j)}. $$
+
+$$
+\widehat{Var}\big(\log\hat S(t)\big) = \sum_{j:t_{(j)}\leq t} \frac{d_j}{n_j(n_j-d_j)}.
+$$
+
 Finally, apply the delta method once more to transform back from $\log S$ to $S$: with $S = \exp(\log S)$, $\frac{dS}{d(\log S)} = S$, so
-$$ \widehat{Var}\big(\hat S(t)\big) \approx \hat S(t)^2 \cdot \widehat{Var}\big(\log\hat S(t)\big) = \hat S(t)^2 \sum_{j:t_{(j)}\leq t} \frac{d_j}{n_j(n_j-d_j)}, $$
+
+$$
+\widehat{Var}\big(\hat S(t)\big) \approx \hat S(t)^2 \cdot \widehat{Var}\big(\log\hat S(t)\big) = \hat S(t)^2 \sum_{j:t_{(j)}\leq t} \frac{d_j}{n_j(n_j-d_j)},
+$$
+
 which is exactly Greenwood's formula.
 
 </details>
@@ -154,17 +242,37 @@ Show that the log-rank test statistic is the score test for $H_0:\beta=0$ in a C
 <summary>Solution</summary>
 
 The Cox partial log-likelihood is $\ell(\beta) = \sum_{j=1}^k \left[x_{(j)}\beta - \log\sum_{l\in R(t_{(j)})} e^{x_l\beta}\right]$ for a single covariate. The score is
-$$ U(\beta) = \frac{d\ell}{d\beta} = \sum_{j=1}^k \left[x_{(j)} - \frac{\sum_{l\in R(t_{(j)})} x_l e^{x_l\beta}}{\sum_{l\in R(t_{(j)})}e^{x_l\beta}}\right]. $$
+
+$$
+U(\beta) = \frac{d\ell}{d\beta} = \sum_{j=1}^k \left[x_{(j)} - \frac{\sum_{l\in R(t_{(j)})} x_l e^{x_l\beta}}{\sum_{l\in R(t_{(j)})}e^{x_l\beta}}\right].
+$$
+
 At $\beta=0$, $e^{x_l\beta}=1$ for all $l$, so the weighted average collapses to a simple average over the risk set:
-$$ \frac{\sum_{l\in R(t_{(j)})}x_l}{|R(t_{(j)})|} = \frac{n_{1j}}{n_j}, $$
+
+$$
+\frac{\sum_{l\in R(t_{(j)})}x_l}{|R(t_{(j)})|} = \frac{n_{1j}}{n_j},
+$$
+
 since $x_l\in\{0,1\}$ and $\sum_l x_l = n_{1j}$ (number of group-1 subjects at risk), $|R(t_{(j)})|=n_j$. Also $x_{(j)}=1$ if the subject who failed at $t_{(j)}$ is in group 1, else $0$; that is, $x_{(j)}$ is the observed count $O_{1j}\in\{0,1\}$ (since exactly one event per distinct time in the no-ties case) and $n_{1j}/n_j = E_{1j}/d_j$ with $d_j=1$. Hence
-$$ U(0) = \sum_{j=1}^k \big(O_{1j}-E_{1j}\big), $$
+
+$$
+U(0) = \sum_{j=1}^k \big(O_{1j}-E_{1j}\big),
+$$
+
 exactly the log-rank numerator.
 
 The observed/expected information at $\beta=0$ is $-\ell''(\beta)$ evaluated at $\beta=0$; a standard calculation for the Cox partial likelihood gives, at each risk set, a "weighted variance" term
-$$ -\frac{d^2\ell_j}{d\beta^2}\bigg|_{\beta=0} = \frac{\sum_l x_l^2}{n_j} - \left(\frac{\sum_l x_l}{n_j}\right)^2 = \frac{n_{1j}}{n_j}-\left(\frac{n_{1j}}{n_j}\right)^2 = \frac{n_{1j}}{n_j}\cdot\frac{n_{2j}}{n_j} = \frac{n_{1j}n_{2j}}{n_j^2} $$
+
+$$
+-\frac{d^2\ell_j}{d\beta^2}\bigg|_{\beta=0} = \frac{\sum_l x_l^2}{n_j} - \left(\frac{\sum_l x_l}{n_j}\right)^2 = \frac{n_{1j}}{n_j}-\left(\frac{n_{1j}}{n_j}\right)^2 = \frac{n_{1j}}{n_j}\cdot\frac{n_{2j}}{n_j} = \frac{n_{1j}n_{2j}}{n_j^2}
+$$
+
 (using $x_l^2=x_l$ for binary $x_l$). Summing over event times gives $I(0) = \sum_j n_{1j}n_{2j}/n_j^2$. This differs from the log-rank $V_j = n_{1j}n_{2j}d_j(n_j-d_j)/[n_j^2(n_j-1)]$ only by the finite-population correction factor $d_j(n_j-d_j)/(n_j-1)$, which equals $1$ when $d_j=1$ (the no-ties case used throughout this lesson's examples), since then $d_j(n_j-d_j)/(n_j-1) = 1\cdot(n_j-1)/(n_j-1)=1$. So under no ties, $I(0) = \sum_j V_j$ exactly, and
-$$ \frac{U(0)^2}{I(0)} = \frac{\left(\sum_j(O_{1j}-E_{1j})\right)^2}{\sum_j V_j} = Z^2_{\text{log-rank}}, $$
+
+$$
+\frac{U(0)^2}{I(0)} = \frac{\left(\sum_j(O_{1j}-E_{1j})\right)^2}{\sum_j V_j} = Z^2_{\text{log-rank}},
+$$
+
 confirming that the log-rank test is precisely the Cox partial-likelihood score test for $\beta=0$ with a single binary covariate (with ties, the two differ by the finite-population correction, which is why software sometimes reports "Score test" and "Log-rank test" as extremely close but not bit-identical numbers when there are tied event times).
 
 </details>
@@ -184,14 +292,25 @@ Order the data: $t=2$ (event), $t=3$ (1 event + 1 censored, tie), $t=5$ (event),
 - $t=3$: $n_2=5$ (one subject removed after $t=2$), $d_2=1$ (one event; the co-occurring censored observation does not reduce the risk set for computing this factor, but both the event and the censoring reduce the risk set for later times) $\Rightarrow$ factor $=4/5$; risk set drops by $d_2 + (\text{censored at }t=3) = 1+1=2$, so $n_3 = 5-2=3$.
 - $t=5$: $n_3=3$, $d_3=1$ $\Rightarrow$ factor $=2/3$.
 
-$$ \hat S(2) = 5/6 = 0.8333, \qquad \hat S(3) = 0.8333\times4/5 = 0.6667, \qquad \hat S(5) = 0.6667\times2/3 = 0.4444. $$
+$$
+\hat S(2) = 5/6 = 0.8333, \qquad \hat S(3) = 0.8333\times4/5 = 0.6667, \qquad \hat S(5) = 0.6667\times2/3 = 0.4444.
+$$
 
 **Greenwood variance at $t=5$:**
-$$ \sum_{j:t_{(j)}\leq5} \frac{d_j}{n_j(n_j-d_j)} = \frac{1}{6\times5}+\frac{1}{5\times4}+\frac{1}{3\times2} = 0.03333+0.05+0.16667 = 0.25000. $$
-$$ \widehat{Var}(\hat S(5)) = 0.4444^2 \times 0.25 = 0.19753\times0.25 = 0.049383, \qquad SE = \sqrt{0.049383} = 0.2222. $$
+
+$$
+\sum_{j:t_{(j)}\leq5} \frac{d_j}{n_j(n_j-d_j)} = \frac{1}{6\times5}+\frac{1}{5\times4}+\frac{1}{3\times2} = 0.03333+0.05+0.16667 = 0.25000.
+$$
+
+$$
+\widehat{Var}(\hat S(5)) = 0.4444^2 \times 0.25 = 0.19753\times0.25 = 0.049383, \qquad SE = \sqrt{0.049383} = 0.2222.
+$$
 
 **95% CI (normal approximation):**
-$$ \hat S(5) \pm 1.96\times SE = 0.4444 \pm 1.96(0.2222) = 0.4444 \pm 0.4355 = (0.0089,\ 0.8799). $$
+
+$$
+\hat S(5) \pm 1.96\times SE = 0.4444 \pm 1.96(0.2222) = 0.4444 \pm 0.4355 = (0.0089,\ 0.8799).
+$$
 
 This interval is very wide, reflecting the small risk sets late in follow-up (only 3 subjects at risk by $t=5$), and it comes close to the boundary at 0, a sign that with even slightly different data the naive normal-approximation interval could exceed $[0,1]$. In practice one would instead compute the interval on the $\log(-\log \hat S)$ scale and back-transform to guarantee the endpoints stay within $[0,1]$; the simple normal-approximation interval computed here is adequate pedagogically but would not be the production-quality choice for such a small risk set.
 


### PR DESCRIPTION
**This pull request makes the following changes**
* Fixes broken math rendering across the docs: display equations written as single-line `$$ eq $$` glued directly to prose (no blank line) are not parsed as display math by MyST dollarmath, so the `$` pairing cascades and the following sentences render as run-on italic (visible on the live site, e.g. Statistics 301 → IRT → "Item and Test Information").
* Normalizes every affected lesson to the standalone-block form (blank line before/after the `$$` fences). Whitespace-only change — no prose or math content altered.
* Affected: Statistics301 Ch3 (4 lessons), Datascience101 FCNN, MLCrashCourse decision-trees & k-means.
* Adds a CLAUDE.md rule so lesson authors keep `$$` blocks blank-separated.

**Why a second PR:** the fix commit landed on `statistics-301` just after PR #26 was already merged, so it missed the merge. The live site deploys only from `main`, so it still shows the pre-fix math until this lands.

**Checklist**
* [x] I have read the [CONTRIBUTING](./CONTRIBUTING.md) document.
* [x] I have created a new branch and made my changes over it.
* [ ] There is an issue created for this pull request.

**Additional context**
Verified with a clean local sphinx build: the previously-glued sections now render as proper `\[...\]` display blocks with normal prose between them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)